### PR TITLE
fix(react/hooks): fix useMount effect with clear effect

### DIFF
--- a/components/react/hooks/src/useMount/index.js
+++ b/components/react/hooks/src/useMount/index.js
@@ -7,6 +7,6 @@ export default function useMount(effect) {
       clean = await effect()
     }
     doEffect()
-    return () => clean()
+    return () => typeof clean === 'function' && clean()
   }, []) // eslint-disable-line
 }

--- a/components/react/hooks/src/useMount/index.js
+++ b/components/react/hooks/src/useMount/index.js
@@ -1,5 +1,12 @@
 import {useEffect} from 'react'
 
 export default function useMount(effect) {
-  useEffect(effect, [])
+  useEffect(() => {
+    let clean = () => {}
+    async function doEffect() {
+      clean = await effect()
+    }
+    doEffect()
+    return () => clean()
+  }, []) // eslint-disable-line
 }

--- a/components/react/hooks/src/useMount/index.js
+++ b/components/react/hooks/src/useMount/index.js
@@ -1,7 +1,5 @@
 import {useEffect} from 'react'
 
 export default function useMount(effect) {
-  useEffect(() => {
-    effect()
-  }, []) // eslint-disable-line
+  useEffect(effect, [])
 }


### PR DESCRIPTION
Fix to allow cleaning effects on hook
Fix not to cheat the deps `[]` of React -> `// eslint-disable-line`

Test where I run tests to compare the two different `useMount`:
[https://codesandbox.io/s/test-usemount-k9y43](https://codesandbox.io/s/test-usemount-k9y43)
`<FirstContent />` uses the current `useMount` and when unmounted does not clean the effect while `<SecondContent />` using the corrected `useMount` does.