### PR TITLE
feat(card/article): make card/article pass on type prop to TagChip

### DIFF
--- a/components/card/article/src/index.js
+++ b/components/card/article/src/index.js
@@ -44,9 +44,11 @@ export default function CardArticle({
   tagChip: TagChip,
   comments,
   lazyLoad,
+  tagClassName,
   featured,
   video
 }) {
+  const suiTagClassName = cx('sui-CardArticle-tag', tagClassName)
   const cardInfoClassName = cx('sui-CardArticle-info', {
     'is-featured': featured
   })
@@ -71,6 +73,7 @@ export default function CardArticle({
               label={tag.text}
               link={tag.url}
               linkFactory={Link}
+              className={suiTagClassName}
               type={tag.type}
             />
           )}

--- a/components/card/article/src/index.js
+++ b/components/card/article/src/index.js
@@ -44,16 +44,13 @@ export default function CardArticle({
   tagChip: TagChip,
   comments,
   lazyLoad,
-  tagClassName,
   featured,
   video
 }) {
-  const suiTagClassName = cx('sui-CardArticle-tag', tagClassName)
   const cardInfoClassName = cx('sui-CardArticle-info', {
     'is-featured': featured
   })
   const MediaIcon = media.icon || MediaPlay
-
   return (
     <div className="sui-CardArticle">
       <Link href={link} className="sui-CardArticle-link" title={title}>
@@ -74,7 +71,7 @@ export default function CardArticle({
               label={tag.text}
               link={tag.url}
               linkFactory={Link}
-              className={suiTagClassName}
+              type={tag.type}
             />
           )}
           {comments && _renderComments(comments, Link)}


### PR DESCRIPTION
Our TagChip component (encapsulating AtomTag) passed as a prop to card/article accepts a type property that makes it use a different CSS class accordingly. Hence, we need card/article to pass down that prop.