### PR TITLE
feat(card/arrow): refactor card arrow component allow optional elements

### DIFF
--- a/components/card/arrow/src/index.js
+++ b/components/card/arrow/src/index.js
@@ -14,12 +14,16 @@ const CardArrow = ({media, text, icon, linkFactory: Link, link}) => {
   return (
     <div className="sui-CardArrow">
       <Link className="sui-CardArrow-link" href={link}>
-        <div className="sui-CardArrow-img">
-          <AtomImage src={media.src} alt={media.alt} />
-        </div>
+        {media && (
+          <div className="sui-CardArrow-img">
+            <AtomImage src={media.src} alt={media.alt} />
+          </div>
+        )}
         <div className="sui-CardArrow-inner">
           <h1 className="sui-CardArrow-innerTitle">{text.title}</h1>
-          <p className="sui-CardArrow-innerDescription">{text.description}</p>
+          {text.description && (
+            <p className="sui-CardArrow-innerDescription">{text.description}</p>
+          )}
         </div>
         <Icon svgClass="sui-CardArrow-icon" className="sui-CardArrow-icon" />
       </Link>
@@ -36,13 +40,13 @@ CardArrow.propTypes = {
   media: PropTypes.shape({
     src: PropTypes.string.isRequired,
     alt: PropTypes.string
-  }).isRequired,
+  }),
   /**
    * Text title/description props
    */
   text: PropTypes.shape({
     title: PropTypes.string.isRequired,
-    description: PropTypes.string.isRequired
+    description: PropTypes.string
   }).isRequired,
   /**
    * Icon optional prop

--- a/components/card/arrow/src/index.js
+++ b/components/card/arrow/src/index.js
@@ -20,7 +20,7 @@ const CardArrow = ({media, text, icon, linkFactory: Link, link}) => {
           </div>
         )}
         <div className="sui-CardArrow-inner">
-          <h1 className="sui-CardArrow-innerTitle">{text.title}</h1>
+          <h3 className="sui-CardArrow-innerTitle">{text.title}</h3>
           {text.description && (
             <p className="sui-CardArrow-innerDescription">{text.description}</p>
           )}

--- a/components/card/arrow/src/index.scss
+++ b/components/card/arrow/src/index.scss
@@ -4,9 +4,11 @@
 @import '~@s-ui/react-atom-image/lib/index';
 
 $w-card-arrow-img: 150px !default;
+$bdrs-card-arrow: 0 !default;
 
 .sui-CardArrow {
   @include sui-card;
+  border-radius: $bdrs-card-arrow;
 
   &-link {
     @include reset-link;
@@ -26,6 +28,7 @@ $w-card-arrow-img: 150px !default;
     &Title {
       font-size: $fz-s;
       margin-top: 0;
+      margin-bottom: 0;
     }
     flex: 1;
     padding: $p-l;

--- a/demo/card/arrow/playground
+++ b/demo/card/arrow/playground
@@ -10,6 +10,10 @@ const text = {
   description: 'Puedes insertar hasta 2 anuncios gratis y actualizarlos tanto como tu quieras.'
 }
 
+const text2 = {
+  title: 'Publica como Particular'
+}
+
 const icon = () => (
   <svg viewBox="0 0 64 64" className="sui-CardArrow-icon">
     <path d="M18,62a2,2,0,0,1-1.41-3.41L43.17,32,16.59,5.41a2,2,0,0,1,2.83-2.83L48.83,32,19.41,61.41A2,2,0,0,1,18,62Z" />
@@ -23,5 +27,9 @@ const suiCardArrowStyle = {
 return (
   <div style={suiCardArrowStyle}>
     <CardArrow media={media} text={text} icon={icon} link={link}/>
+    <br />
+    <CardArrow text={text} icon={icon} link={link}/>
+    <br />
+    <CardArrow text={text2} icon={icon} link={link}/>
   </div>
 )


### PR DESCRIPTION
- Refactor card/arrow component to allow optional elements like image and description
- Add border-radius scss variable with default value to 0

*Desktop*
<img width="654" alt="imagen" src="https://user-images.githubusercontent.com/17271365/72806424-74578180-3c55-11ea-9328-0c680b0c4225.png">

---

*Mobile*
<img width="390" alt="imagen" src="https://user-images.githubusercontent.com/17271365/72806470-8cc79c00-3c55-11ea-83ad-ff337d6983aa.png">


