### PR TITLE
feat(root): add session storage disable-tealium

### DIFF
--- a/components/tracking/view/src/index.js
+++ b/components/tracking/view/src/index.js
@@ -24,7 +24,8 @@ class TrackingView extends Component {
   render() {
     if (
       typeof window !== 'undefined' &&
-      window.document.location.href.match('disable-tealium')
+      window.document.location.href.match('disable-tealium') ||
+      sessionStorage.getItem('disable-tealium')
     ) {
       return null
     }

--- a/components/tracking/view/src/index.js
+++ b/components/tracking/view/src/index.js
@@ -25,7 +25,7 @@ class TrackingView extends Component {
     if (
       typeof window !== 'undefined' &&
       (window.document.location.href.match('disable-tealium') ||
-      sessionStorage.getItem('disable-tealium'))
+        window.sessionStorage.getItem('disable-tealium'))
     ) {
       return null
     }

--- a/components/tracking/view/src/index.js
+++ b/components/tracking/view/src/index.js
@@ -24,8 +24,8 @@ class TrackingView extends Component {
   render() {
     if (
       typeof window !== 'undefined' &&
-      window.document.location.href.match('disable-tealium') ||
-      sessionStorage.getItem('disable-tealium')
+      (window.document.location.href.match('disable-tealium') ||
+      sessionStorage.getItem('disable-tealium'))
     ) {
       return null
     }


### PR DESCRIPTION
- during e2e tests it is super messy to handle `disable-tealium` with the url queryParameters (for example checking the resulting url when a button is clicked in the app).
- So, this PR adds the possibility to handle the `disable-tealium` flag via sessionStorage.