### PR TITLE
perf(image/slider): move image/slider to function and stop using cloneDeep

### DIFF
--- a/components/image/slider/package.json
+++ b/components/image/slider/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@s-ui/component-dependencies": "1",
     "@schibstedspain/sui-svgiconset": "1",
-    "lodash.clonedeep": "4.5.0",
     "react-slidy": "4"
   }
 }


### PR DESCRIPTION
Move image/slider from class to function.
![image](https://user-images.githubusercontent.com/1561955/73267840-12a99100-41da-11ea-849c-104893085bf2.png)


👋 Remove lodash.clonedeep not needed.
![image](https://user-images.githubusercontent.com/1561955/73267728-ea219700-41d9-11ea-9fa2-43e9eeceebfc.png)
