### PR TITLE
Feature/add open events to topbar composable

### DIFF
--- a/components/react/hooks/src/index.js
+++ b/components/react/hooks/src/index.js
@@ -7,6 +7,7 @@ export default function ReactHooks() {
   return null
 }
 
+export {default as useLegacyState} from './useLegacyState'
 export {default as useMount} from './useMount'
 export {default as useOnScreen, useNearScreen} from './useOnScreen'
-export {default as useLegacyState} from './useLegacyState'
+export {default as usePrevious} from './usePrevious'

--- a/components/react/hooks/src/usePrevious/index.js
+++ b/components/react/hooks/src/usePrevious/index.js
@@ -9,7 +9,7 @@ export default function usePrevious(value) {
   return ref.current
 }
 
-usePrevious.displayName = 'HookUseOnScreen'
+usePrevious.displayName = 'HookUsePrevious'
 usePrevious.propTypes = {
   value: PropTypes.any
 }

--- a/components/react/hooks/src/usePrevious/index.js
+++ b/components/react/hooks/src/usePrevious/index.js
@@ -1,0 +1,15 @@
+import {useEffect, useRef} from 'react'
+import PropTypes from 'prop-types'
+
+export default function usePrevious(value) {
+  const ref = useRef()
+  useEffect(() => {
+    ref.current = value
+  }, [value])
+  return ref.current
+}
+
+usePrevious.displayName = 'HookUseOnScreen'
+usePrevious.propTypes = {
+  value: PropTypes.any
+}

--- a/components/topbar/composable/package.json
+++ b/components/topbar/composable/package.json
@@ -9,7 +9,8 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@schibstedspain/sui-react-hooks": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/topbar/composable/src/sui-topbar-composable-dropdown/index.js
+++ b/components/topbar/composable/src/sui-topbar-composable-dropdown/index.js
@@ -25,7 +25,7 @@ function DropdownMenu({
     /**
      * Only run open events:
      *  - After first render
-     *  - When isOpen actually changes
+     *  - When displayMenu actually changes
      **/
     if (
       typeof previousDisplayMenu === 'undefined' ||

--- a/components/topbar/composable/src/sui-topbar-composable-dropdown/index.js
+++ b/components/topbar/composable/src/sui-topbar-composable-dropdown/index.js
@@ -2,10 +2,40 @@ import React, {useEffect, useRef, useState} from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-function DropdownMenu({caret, classname, entries, icon, label, renderOnClick}) {
+import {usePrevious} from '@schibstedspain/sui-react-hooks'
+
+const noop = () => {}
+
+function DropdownMenu({
+  caret,
+  classname,
+  entries,
+  icon,
+  label,
+  onClose = noop,
+  onOpen = noop,
+  renderOnClick
+}) {
   const [displayMenu, setDisplayMenu] = useState(false)
   const [renderBody, setRenderBody] = useState(false)
   const wrapperRef = useRef()
+
+  const previousDisplayMenu = usePrevious(displayMenu)
+  useEffect(() => {
+    /**
+     * Only run open events:
+     *  - After first render
+     *  - When isOpen actually changes
+     **/
+    if (
+      typeof previousDisplayMenu === 'undefined' ||
+      displayMenu === previousDisplayMenu
+    ) {
+      return
+    }
+    const openEvent = displayMenu ? onOpen : onClose
+    openEvent()
+  }, [displayMenu, onClose, onOpen, previousDisplayMenu])
 
   const closeMenu = ({target}) => {
     const isClickOutsideDropdown = !wrapperRef.current.contains(target)
@@ -60,5 +90,7 @@ DropdownMenu.propTypes = {
   entries: PropTypes.array,
   icon: PropTypes.element,
   label: PropTypes.string,
+  onClose: PropTypes.func,
+  onOpen: PropTypes.func,
   renderOnClick: PropTypes.bool
 }


### PR DESCRIPTION
## 🎯 Why?

Some team at Real Estate needs events to be aware of `DropdownMenu` component opening or closing. FYI this PR follows the very same approach that was implemented here → SUI-Components/sui-components#991

## ➕ Bonus

Since we already have a `react/hooks` component within this repo I also added the `usePrevious` hook there.