### PR TITLE
feat(form/builder): add check of hidden property on fieldset component

### DIFF
--- a/components/form/builder/src/FieldSet/index.js
+++ b/components/form/builder/src/FieldSet/index.js
@@ -16,6 +16,11 @@ const FieldSet = ({
   errors
 }) => {
   const {fields = [], label} = fieldset
+
+  if (fieldset.hidden) {
+    return null
+  }
+
   return (
     <fieldset className={`${baseClass}-FieldSet`}>
       {label && (


### PR DESCRIPTION
At Carfactory, some rules will result in hiding `Fieldset`s , so we add that check before the `formBuilder` render a `Fieldset`