### PR TITLE
feat(form/builder): add field alerts

### DIFF
--- a/components/form/builder/src/Checkbox/index.js
+++ b/components/form/builder/src/Checkbox/index.js
@@ -5,8 +5,10 @@ import {field, createComponentMemo} from '../prop-types'
 import MoleculeCheckboxField from '@s-ui/react-molecule-checkbox-field'
 import IconCheck from '../Icons/IconCheck'
 
-const Checkbox = ({checkbox, tabIndex, onChange, onBlur, errors}) => {
+const Checkbox = ({checkbox, tabIndex, onChange, onBlur, errors, alerts}) => {
   const errorMessages = errors[checkbox.id]
+  const alertMessages = alerts[checkbox.id]
+
   let checked = 'false'
   try {
     checked = JSON.parse(checkbox.value)
@@ -51,6 +53,9 @@ const Checkbox = ({checkbox, tabIndex, onChange, onBlur, errors}) => {
     }),
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
+    }),
+    ...(!!alertMessages && {
+      alertText: alertMessages.join('\n')
     })
   }
 
@@ -73,7 +78,8 @@ Checkbox.propTypes = {
   checkbox: field,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default React.memo(Checkbox, createComponentMemo('checkbox'))

--- a/components/form/builder/src/FieldSet/index.js
+++ b/components/form/builder/src/FieldSet/index.js
@@ -13,7 +13,8 @@ const FieldSet = ({
   onChange,
   onBlur,
   fieldSize,
-  errors
+  errors,
+  alerts
 }) => {
   const {fields = [], label} = fieldset
 
@@ -38,6 +39,7 @@ const FieldSet = ({
             tabIndex={tabIndex + index * 0.1}
             fieldSize={fieldSize}
             errors={errors}
+            alerts={alerts}
           />
         ))}
       </div>
@@ -52,7 +54,8 @@ FieldSet.propTypes = {
   fieldset: field,
   tabIndex: PropTypes.number,
   fieldSize: PropTypes.string,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default FieldSet

--- a/components/form/builder/src/InlineButton/index.js
+++ b/components/form/builder/src/InlineButton/index.js
@@ -5,8 +5,9 @@ import {field, createComponentMemo} from '../prop-types'
 import MoleculeButtonGroup from '@s-ui/react-molecule-button-group'
 import Button from '@s-ui/react-atom-button'
 
-const InlineButton = ({inlineButton, tabIndex, onChange, errors}) => {
+const InlineButton = ({inlineButton, tabIndex, onChange, errors, alerts}) => {
   const errorMessages = errors[inlineButton.id]
+  const alertMessages = alerts[inlineButton.id]
 
   const onClickHandler = value => {
     return onChange(inlineButton.id, value)
@@ -24,6 +25,9 @@ const InlineButton = ({inlineButton, tabIndex, onChange, errors}) => {
     }),
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
+    }),
+    ...(!!alertMessages && {
+      alertText: alertMessages.join('\n')
     })
   }
 
@@ -58,7 +62,8 @@ InlineButton.propTypes = {
   inlineButton: field,
   tabIndex: PropTypes.number,
   onChange: PropTypes.func,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default React.memo(InlineButton, createComponentMemo('inlineButton'))

--- a/components/form/builder/src/Input/index.js
+++ b/components/form/builder/src/Input/index.js
@@ -23,9 +23,12 @@ const Input = ({
   size,
   leftAddon,
   rightAddon,
-  errors
+  errors,
+  alerts
 }) => {
   const errorMessages = errors[input.id]
+  const alertMessages = alerts[input.id]
+
   const onChangeCallback = useCallback(
     evt => {
       return onChange(input.id, evt.target.value)
@@ -93,6 +96,9 @@ const Input = ({
     }),
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
+    }),
+    ...(!!alertMessages && {
+      alertText: alertMessages.join('\n')
     })
   }
 
@@ -137,7 +143,8 @@ Input.propTypes = {
   size: PropTypes.string,
   leftAddon: PropTypes.string,
   rightAddon: PropTypes.string,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default React.memo(Input, createComponentMemo('input'))

--- a/components/form/builder/src/ProxyField/index.js
+++ b/components/form/builder/src/ProxyField/index.js
@@ -11,23 +11,31 @@ import NumericField from '../Standard/Fields/Numeric'
 import FieldSetField from '../Standard/Fields/FieldSet'
 import PickerField from '../Standard/Fields/Picker'
 
-const ProxyField = ({field, tabIndex, onChange, onBlur, fieldSize, errors}) => {
+const ProxyField = ({
+  field,
+  tabIndex,
+  onChange,
+  onBlur,
+  fieldSize,
+  errors,
+  alerts
+}) => {
   let Field
   switch (field.type) {
     case FIELDS.TEXT:
-      Field = TextField({field, tabIndex, onChange, onBlur, errors})
+      Field = TextField({field, tabIndex, onChange, onBlur, errors, alerts})
       break
 
     case FIELDS.NUMERIC:
-      Field = NumericField({field, tabIndex, onChange, onBlur, errors})
+      Field = NumericField({field, tabIndex, onChange, onBlur, errors, alerts})
       break
 
     case FIELDS.FIELDSET:
-      Field = FieldSetField({field, tabIndex, onChange, onBlur, errors})
+      Field = FieldSetField({field, tabIndex, onChange, onBlur, errors, alerts})
       break
 
     case FIELDS.PICKER:
-      Field = PickerField({field, tabIndex, onChange, onBlur, errors})
+      Field = PickerField({field, tabIndex, onChange, onBlur, errors, alerts})
       break
 
     default:
@@ -48,7 +56,8 @@ ProxyField.propTypes = {
   tabIndex: PropTypes.number,
   field,
   fieldSize: PropTypes.string,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default ProxyField

--- a/components/form/builder/src/Select/Autosuggest/index.js
+++ b/components/form/builder/src/Select/Autosuggest/index.js
@@ -25,9 +25,12 @@ const AutosuggestSelect = ({
   onChange,
   onBlur,
   size,
-  errors
+  errors,
+  alerts
 }) => {
   const errorMessages = errors[select.id]
+  const alertMessages = alerts[select.id]
+
   const {datalist = []} = select
   const fromTextToValueWithDatalist = fromTextToValue(datalist)
   const fromValueToTextWithDatalist = fromValueToText(datalist)
@@ -83,6 +86,9 @@ const AutosuggestSelect = ({
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
     }),
+    ...(!!alertMessages && {
+      alertText: alertMessages.join('\n')
+    }),
     selectSize: size,
     ...constraintsProps
   }
@@ -127,7 +133,8 @@ AutosuggestSelect.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   size: PropTypes.string,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default React.memo(AutosuggestSelect, createComponentMemo('select'))

--- a/components/form/builder/src/Select/Default/index.js
+++ b/components/form/builder/src/Select/Default/index.js
@@ -7,8 +7,17 @@ import MoleculeSelectField from '@s-ui/react-molecule-select-field'
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 import IconChevronDown from '../../Icons/IconChevronDown'
 
-const DefaultSelect = ({select, tabIndex, onChange, onBlur, size, errors}) => {
+const DefaultSelect = ({
+  select,
+  tabIndex,
+  onChange,
+  onBlur,
+  size,
+  errors,
+  alerts
+}) => {
   const errorMessages = errors[select.id]
+  const alertMessages = alerts[select.id]
 
   const onChangeCallback = useCallback(
     (evt, {value}) => {
@@ -54,6 +63,9 @@ const DefaultSelect = ({select, tabIndex, onChange, onBlur, size, errors}) => {
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
     }),
+    ...(!!alertMessages && {
+      alertText: alertMessages.join('\n')
+    }),
     selectSize: size,
     ...constraintsProps
   }
@@ -89,7 +101,8 @@ DefaultSelect.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   size: PropTypes.string,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default React.memo(DefaultSelect, createComponentMemo('select'))

--- a/components/form/builder/src/Select/index.js
+++ b/components/form/builder/src/Select/index.js
@@ -8,7 +8,7 @@ import {FIELDS, DISPLAYS} from '../Standard'
 import DefaultSelect from './Default'
 import AutosuggestSelect from './Autosuggest'
 
-const Select = ({select, onChange, onBlur, tabIndex, size, errors}) => {
+const Select = ({select, onChange, onBlur, tabIndex, size, errors, alerts}) => {
   let Field
   switch (select.display) {
     case DISPLAYS[FIELDS.PICKER].AUTOCOMPLETE:
@@ -20,6 +20,7 @@ const Select = ({select, onChange, onBlur, tabIndex, size, errors}) => {
           tabIndex={tabIndex}
           size={size}
           errors={errors}
+          alerts={alerts}
         />
       )
       break
@@ -34,6 +35,7 @@ const Select = ({select, onChange, onBlur, tabIndex, size, errors}) => {
           tabIndex={tabIndex}
           size={size}
           errors={errors}
+          alerts={alerts}
         />
       )
   }
@@ -47,7 +49,8 @@ Select.propTypes = {
   tabIndex: PropTypes.number,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default Select

--- a/components/form/builder/src/Standard/Fields/FieldSet/index.js
+++ b/components/form/builder/src/Standard/Fields/FieldSet/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import FieldSet from '../../../FieldSet'
 
-const FieldSetField = ({field, tabIndex, onChange, onBlur, errors}) => {
+const FieldSetField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
   return (
     <FieldSet
       fieldset={field}
@@ -11,6 +11,7 @@ const FieldSetField = ({field, tabIndex, onChange, onBlur, errors}) => {
       onBlur={onBlur}
       tabIndex={tabIndex}
       errors={errors}
+      alerts={alerts}
     />
   )
 }
@@ -20,7 +21,8 @@ FieldSetField.propTypes = {
   onBlur: PropTypes.func,
   tabIndex: PropTypes.number,
   field: PropTypes.object,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default FieldSetField

--- a/components/form/builder/src/Standard/Fields/Numeric/index.js
+++ b/components/form/builder/src/Standard/Fields/Numeric/index.js
@@ -5,7 +5,7 @@ import Input from '../../../Input'
 
 import {FIELDS, DISPLAYS} from '../../index'
 
-const NumericField = ({field, tabIndex, onChange, onBlur, errors}) => {
+const NumericField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
   /* TODO: add the possibility to customize rightAddon in the DSL */
   if (field.display === DISPLAYS[FIELDS.NUMERIC].MONEY) {
     return (
@@ -16,6 +16,7 @@ const NumericField = ({field, tabIndex, onChange, onBlur, errors}) => {
         tabIndex={tabIndex}
         rightAddon="€"
         errors={errors}
+        alerts={alerts}
       />
     )
   } else {
@@ -26,6 +27,7 @@ const NumericField = ({field, tabIndex, onChange, onBlur, errors}) => {
         onBlur={onBlur}
         tabIndex={tabIndex}
         errors={errors}
+        alerts={alerts}
       />
     )
   }
@@ -35,7 +37,8 @@ NumericField.propTypes = {
   onChange: PropTypes.func,
   tabIndex: PropTypes.number,
   field: PropTypes.object,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default NumericField

--- a/components/form/builder/src/Standard/Fields/Picker/index.js
+++ b/components/form/builder/src/Standard/Fields/Picker/index.js
@@ -8,7 +8,7 @@ import InlineButton from '../../../InlineButton'
 
 import {FIELDS, DISPLAYS} from '../../index'
 
-const PickerField = ({field, tabIndex, onChange, onBlur, errors}) => {
+const PickerField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
   if (field.display === DISPLAYS[FIELDS.PICKER].SWITCH) {
     return (
       <Switch
@@ -17,6 +17,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors}) => {
         onBlur={onBlur}
         tabIndex={tabIndex}
         errors={errors}
+        alerts={alerts}
       />
     )
   } else if (
@@ -30,6 +31,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors}) => {
         onBlur={onBlur}
         tabIndex={tabIndex}
         errors={errors}
+        alerts={alerts}
       />
     )
   } else if (field.display === DISPLAYS[FIELDS.PICKER].RADIO) {
@@ -42,6 +44,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors}) => {
         onBlur={onBlur}
         tabIndex={tabIndex}
         errors={errors}
+        alerts={alerts}
       />
     )
   } else if (field.display === DISPLAYS[FIELDS.PICKER].BUTTON_INLINE) {
@@ -52,6 +55,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors}) => {
         onBlur={onBlur}
         tabIndex={tabIndex}
         errors={errors}
+        alerts={alerts}
       />
     )
   } else {
@@ -63,6 +67,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors}) => {
         onBlur={onBlur}
         tabIndex={tabIndex}
         errors={errors}
+        alerts={alerts}
       />
     )
   }
@@ -73,7 +78,8 @@ PickerField.propTypes = {
   onBlur: PropTypes.func,
   tabIndex: PropTypes.number,
   field: PropTypes.object,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default PickerField

--- a/components/form/builder/src/Standard/Fields/Text/index.js
+++ b/components/form/builder/src/Standard/Fields/Text/index.js
@@ -6,7 +6,7 @@ import TextArea from '../../../TextArea'
 
 import {FIELDS, DISPLAYS} from '../../index'
 
-const TextField = ({field, tabIndex, onChange, onBlur, errors}) => {
+const TextField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
   if (field.display === DISPLAYS[FIELDS.TEXT].MULTILINE)
     return (
       <TextArea
@@ -15,6 +15,7 @@ const TextField = ({field, tabIndex, onChange, onBlur, errors}) => {
         onBlur={onBlur}
         tabIndex={tabIndex}
         errors={errors}
+        alerts={alerts}
       />
     )
   return (
@@ -24,6 +25,7 @@ const TextField = ({field, tabIndex, onChange, onBlur, errors}) => {
       onBlur={onBlur}
       tabIndex={tabIndex}
       errors={errors}
+      alerts={alerts}
     />
   )
 }
@@ -33,7 +35,8 @@ TextField.propTypes = {
   onBlur: PropTypes.func,
   tabIndex: PropTypes.number,
   field: PropTypes.object,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default TextField

--- a/components/form/builder/src/Switch/index.js
+++ b/components/form/builder/src/Switch/index.js
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types'
 import {field, createComponentMemo} from '../prop-types'
 import MoleculeSwitch from '@s-ui/react-atom-switch'
 
-const Switch = ({switchField, tabIndex, onChange, errors}) => {
+const Switch = ({switchField, tabIndex, onChange, errors, alerts}) => {
   const errorMessages = errors[switchField.id]
+  const alertMessages = alerts[switchField.id]
 
   const onChangeCallback = useCallback(
     value => {
@@ -31,6 +32,9 @@ const Switch = ({switchField, tabIndex, onChange, errors}) => {
     }),
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
+    }),
+    ...(!!alertMessages && {
+      alertText: alertMessages.join('\n')
     })
   }
 
@@ -53,7 +57,8 @@ Switch.propTypes = {
   tabIndex: PropTypes.number,
   switchField: field,
   onChange: PropTypes.func,
-  errors: PropTypes.objects
+  errors: PropTypes.objects,
+  alerts: PropTypes.objects
 }
 
 export default React.memo(Switch, createComponentMemo('switchField'))

--- a/components/form/builder/src/TextArea/index.js
+++ b/components/form/builder/src/TextArea/index.js
@@ -5,8 +5,9 @@ import {field, createComponentMemo} from '../prop-types'
 
 import MoleculeTextAreaField from '@s-ui/react-molecule-textarea-field'
 
-const TextArea = ({textArea, tabIndex, onChange, onBlur, errors}) => {
+const TextArea = ({textArea, tabIndex, onChange, onBlur, errors, alerts}) => {
   const errorMessages = errors[textArea.id]
+  const alertMessages = alerts[textArea.id]
 
   const onChangeCallback = useCallback(
     evt => {
@@ -49,6 +50,9 @@ const TextArea = ({textArea, tabIndex, onChange, onBlur, errors}) => {
     }),
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
+    }),
+    ...(!!alertMessages && {
+      alertText: alertMessages.join('\n')
     })
   }
 
@@ -87,7 +91,8 @@ TextArea.propTypes = {
   tabIndex: PropTypes.number,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 export default React.memo(TextArea, createComponentMemo('textArea'))

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -22,7 +22,8 @@ const FormBuilder = ({
   urlInterceptor,
   loader,
   fieldSize,
-  errors
+  errors,
+  alerts
 }) => {
   const {fields = [], rules = {}, id: formID} = json.form
   const [stateFields, setStateFields] = useState(fields)
@@ -119,6 +120,7 @@ const FormBuilder = ({
           onBlur={onBlur}
           fieldSize={fieldSize}
           errors={errors}
+          alerts={alerts}
         />
       ))}
       {stateShowSpinner && (
@@ -140,7 +142,8 @@ FormBuilder.propTypes = {
   urlInterceptor: PropTypes.func,
   loader: PropTypes.object,
   fieldSize: PropTypes.oneOf(Object.values(fieldSizes)),
-  errors: PropTypes.object
+  errors: PropTypes.object,
+  alerts: PropTypes.object
 }
 
 FormBuilder.defaultProps = {
@@ -149,7 +152,8 @@ FormBuilder.defaultProps = {
   onBlur: () => {},
   requestInterceptor: ({response}) => response,
   urlInterceptor: () => {},
-  errors: {}
+  errors: {},
+  alerts: {}
 }
 
 export {fieldSizes as formBuilderFieldSizes}

--- a/components/form/builder/src/prop-types/index.js
+++ b/components/form/builder/src/prop-types/index.js
@@ -46,6 +46,8 @@ export const createComponentMemo = field => (nextProps, prevProps) => {
     JSON.stringify(nextProps[field]) === JSON.stringify(prevProps[field]) &&
     nextProps.errors[nextProps[field].id] ===
       prevProps.errors[prevProps[field].id] &&
+    nextProps.alerts[nextProps[field].id] ===
+      prevProps.alerts[prevProps[field].id] &&
     nextProps.onChange === prevProps.onChange
   )
 }


### PR DESCRIPTION
Added the possibility to set alert texts on fields.
With these changes, we only can set these alerts from outside the form, but it may be interesting to do something like constraints but with alerts, defining some rules to set alerts.

Here an example of checkbox with `alertText` :
<img width="976" alt="73649794-e29e3a00-4680-11ea-813a-d196639d67d3" src="https://user-images.githubusercontent.com/37936498/75324987-4aa70100-5878-11ea-817a-cd2b4542c7b0.png">
