### PR TITLE
Feature/molecule form builder add fieldset

### DIFF
--- a/components/form/builder/src/FieldSet/index.js
+++ b/components/form/builder/src/FieldSet/index.js
@@ -5,7 +5,7 @@ import {field} from '../prop-types'
 
 import ProxyField from '../ProxyField'
 
-const baseClass = 'sui-FormBuilder'
+const baseClass = 'sui-FormBuilder-FieldSet'
 
 const FieldSet = ({
   fieldset,
@@ -23,13 +23,13 @@ const FieldSet = ({
   }
 
   return (
-    <fieldset className={`${baseClass}-FieldSet ${baseClass}-${fieldset.id}`}>
+    <fieldset className={`${baseClass} ${baseClass}-${fieldset.id}`}>
       {label && (
         <legend>
           <span>{label}</span>
         </legend>
       )}
-      <div className={`${baseClass}-FieldSetContainer`}>
+      <div className={`${baseClass}Container`}>
         {fields.map((field, index) => (
           <ProxyField
             onChange={onChange}

--- a/components/form/builder/src/FieldSet/index.js
+++ b/components/form/builder/src/FieldSet/index.js
@@ -23,7 +23,7 @@ const FieldSet = ({
   }
 
   return (
-    <fieldset className={`${baseClass}-FieldSet`}>
+    <fieldset className={`${baseClass}-FieldSet ${baseClass}-${fieldset.id}`}>
       {label && (
         <legend>
           <span>{label}</span>


### PR DESCRIPTION
Add ID based classnames to fieldset elements.

Example:
A fieldset defined at JSON with ID `vehiclesSpecs`, previously got the classname `sui-FormBuilder-FieldSet`. Now will get the classname `sui-FormBuilder-FieldSet sui-FormBuilder-FieldSet-vehiclesSpecs`.