### PR TITLE
feat(form/builder): pass input mode prop to atom input

### DIFF
--- a/components/form/builder/src/Input/index.js
+++ b/components/form/builder/src/Input/index.js
@@ -94,6 +94,7 @@ const Input = ({
     ...(input.disabled && {
       disabled: true
     }),
+    ...(input.inputmode && {inputMode: input.inputmode}),
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
     }),

--- a/components/form/builder/src/Input/index.js
+++ b/components/form/builder/src/Input/index.js
@@ -11,8 +11,13 @@ import {FIELDS, DISPLAYS} from '../Standard'
 const DISPLAY = {
   [DISPLAYS[FIELDS.TEXT].EMAIL]: 'email',
   [DISPLAYS[FIELDS.TEXT].PHONE]: 'tel',
+  [DISPLAYS[FIELDS.TEXT].NUMERIC]: 'text',
   [DISPLAYS[FIELDS.TEXT].TEXT]: 'text',
   [DISPLAYS[FIELDS.TEXT].DEFAULT]: 'text'
+}
+
+const INPUT_MODES = {
+  DECIMAL: 'decimal'
 }
 
 const Input = ({
@@ -41,6 +46,10 @@ const Input = ({
   switch (input.type) {
     case FIELDS.TEXT: {
       nextProps = {type: DISPLAY[input.display] || 'text'} // this is the html input type (not the field type related to DSL form-builder)
+
+      if (input.display === DISPLAYS[FIELDS.TEXT].NUMERIC) {
+        nextProps.inputMode = INPUT_MODES.DECIMAL
+      }
 
       const constraints = input.constraints || []
 
@@ -94,7 +103,6 @@ const Input = ({
     ...(input.disabled && {
       disabled: true
     }),
-    ...(input.inputmode && {inputMode: input.inputmode}),
     ...(!!errorMessages && {
       errorText: errorMessages.join('\n')
     }),

--- a/components/form/builder/src/Standard/index.js
+++ b/components/form/builder/src/Standard/index.js
@@ -15,6 +15,7 @@ const DISPLAYS = {
     EMAIL: 'email',
     PHONE: 'phone', // not part of the DSL standard
     TEXT: 'text', // not part of the DSL standard
+    NUMERIC: 'numeric', // not part of the DSL standard
     DEFAULT: ''
   },
   [FIELDS.NUMERIC]: {


### PR DESCRIPTION
If a field type `text` with `numeric` display is defined in JSON field, it will force the input to show numeric keyboards on mobile. Ie:
```
"fields":
    [
        {
            "id":"cashPrice",
            "type":"text",
            "display":"numeric"
        }
    ]
```