### PR TITLE
Fix/lazy loading and spinner

### DIFF
--- a/components/image/lazyLoad/src/index.scss
+++ b/components/image/lazyLoad/src/index.scss
@@ -53,7 +53,7 @@ $aspect-ratios: (
     height: 100%;
     justify-content: center;
     padding: $p-v-large $p-h-large;
-    position: absolute;
+    position: relative;
     width: 100%;
     z-index: 1;
   }

--- a/components/spinner/basic/src/index.scss
+++ b/components/spinner/basic/src/index.scss
@@ -22,6 +22,7 @@
 }
 
 .sui-SpinnerBasic {
+  $self: &;
   display: inline-block;
   line-height: 1;
   margin: $m-spinner;
@@ -48,7 +49,7 @@
     width: $size-spinner-l;
   }
 
-  &--large &-circle {
+  &--large #{$self}-circle {
     border-radius: $size-spinner-l;
     height: $size-spinner-l;
     width: $size-spinner-l;
@@ -69,7 +70,7 @@
     width: $size-spinner-m;
   }
 
-  &--medium &-circle {
+  &--medium #{$self}-circle {
     border-radius: $size-spinner-m;
     height: $size-spinner-m;
     width: $size-spinner-m;
@@ -90,7 +91,7 @@
     width: $size-spinner-s;
   }
 
-  &--small &-circle {
+  &--small #{$self}-circle {
     border-radius: $size-spinner-s;
     height: $size-spinner-s;
     width: $size-spinner-s;


### PR DESCRIPTION
## 🤔  Problem

New Construction detail is not showing Media Gallery.

## 👨‍💻  Solution

- ImageLazyLoad didn't work because `position: absolute` CSS property seems to be not working correctly with `useNearScreen` hook.
- Fix SpinnerBasic component styles because it lost its styles.

## 📷 Preview

### 🥚 Before

![image](https://user-images.githubusercontent.com/13108014/78784489-b915cd80-79a5-11ea-94dc-ec82ffac813d.png)

### 🐣 After

![image](https://user-images.githubusercontent.com/13108014/78784512-c3d06280-79a5-11ea-8910-37b95391d4ee.png)
