### PR TITLE
feat(list/bullet): apply changes to have responsive block & string

### DIFF
--- a/components/list/bullet/src/bullet.js
+++ b/components/list/bullet/src/bullet.js
@@ -1,16 +1,26 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const Bullet = ({illustration, title, text, baseClass: BASE_CLASS}) => {
+const Bullet = ({
+  illustration,
+  title,
+  text,
+  baseClass: BASE_CLASS,
+  isString
+}) => {
   const ITEM_CLASS = `${BASE_CLASS}-item`
   const ILLUSTRATION_CLASS = `${BASE_CLASS}-illustration`
+  const ILLUSTRATION_STRING_CLASS = `${BASE_CLASS}-illustrationString`
   const INNER_CLASS = `${BASE_CLASS}-inner`
   const TITLE_CLASS = `${BASE_CLASS}-title`
   const TEXT_CLASS = `${BASE_CLASS}-text`
 
   return (
     <div className={ITEM_CLASS}>
-      <img className={ILLUSTRATION_CLASS} src={illustration} />
+      {isString && (
+        <h2 className={ILLUSTRATION_STRING_CLASS}>{illustration}</h2>
+      )}
+      {!isString && <img className={ILLUSTRATION_CLASS} src={illustration} />}
       <div className={INNER_CLASS}>
         {title && <h3 className={TITLE_CLASS}>{title}</h3>}
         <p className={TEXT_CLASS}>{text}</p>
@@ -25,7 +35,8 @@ Bullet.propTypes = {
   illustration: PropTypes.string.isRequired,
   title: PropTypes.string,
   text: PropTypes.string.isRequired,
-  baseClass: PropTypes.string.isRequired
+  baseClass: PropTypes.string.isRequired,
+  isString: PropTypes.bool
 }
 
 export default Bullet

--- a/components/list/bullet/src/index.js
+++ b/components/list/bullet/src/index.js
@@ -4,10 +4,13 @@ import Bullet from './bullet.js'
 import cx from 'classnames'
 
 const BASE_CLASS = 'sui-ListBullet'
-
-const ListBullet = ({listItems, responsive, smallFont}) => {
+const RESPONSIVE = {
+  responsive: 'responsive',
+  responsiveBlock: 'responsiveBlock'
+}
+const ListBullet = ({listItems, responsive, smallFont, isString}) => {
   const listBulletClass = cx(BASE_CLASS, {
-    [`${BASE_CLASS}--responsive`]: responsive,
+    [`${BASE_CLASS}--${responsive}`]: Boolean(responsive),
     [`${BASE_CLASS}--smallFont`]: smallFont
   })
 
@@ -15,7 +18,12 @@ const ListBullet = ({listItems, responsive, smallFont}) => {
     <div className={listBulletClass}>
       {listItems &&
         listItems.map((item, index) => (
-          <Bullet {...item} key={index} baseClass={BASE_CLASS} />
+          <Bullet
+            {...item}
+            isString={isString}
+            key={index}
+            baseClass={BASE_CLASS}
+          />
         ))}
     </div>
   )
@@ -38,11 +46,15 @@ ListBullet.propTypes = {
   /**
    * Responsive behaviour
    */
-  responsive: PropTypes.bool,
+  responsive: PropTypes.oneOf(Object.values(RESPONSIVE)),
   /**
    * Small font size
    */
-  smallFont: PropTypes.bool
+  smallFont: PropTypes.bool,
+  /**
+   * Is a String insted of an image
+   */
+  isString: PropTypes.bool
 }
 
 ListBullet.defaultProps = {

--- a/components/list/bullet/src/index.js
+++ b/components/list/bullet/src/index.js
@@ -8,6 +8,7 @@ const RESPONSIVE = {
   responsive: 'responsive',
   responsiveBlock: 'responsiveBlock'
 }
+
 const ListBullet = ({listItems, responsive, smallFont, isString}) => {
   const listBulletClass = cx(BASE_CLASS, {
     [`${BASE_CLASS}--${responsive}`]: Boolean(responsive),

--- a/components/list/bullet/src/index.scss
+++ b/components/list/bullet/src/index.scss
@@ -47,13 +47,6 @@ $mb-list-bullet-responsive-block-text: $m-xxxl * 2 !default;
       text-align: center;
     }
 
-    #{$prefix}-illustration {
-      height: $sz-list-bullet-illustration-l;
-      margin-bottom: $m-xl;
-      margin-right: 0;
-      width: $sz-list-bullet-illustration-l;
-    }
-
     #{$prefix}-text {
       font-size: $fz-m;
       margin-bottom: $mb-list-bullet-responsive-block-text;

--- a/components/list/bullet/src/index.scss
+++ b/components/list/bullet/src/index.scss
@@ -3,11 +3,15 @@
 $sz-list-bullet-illustration-s: 42px !default;
 $sz-list-bullet-illustration-m: 64px !default;
 $sz-list-bullet-illustration-l: 72px !default;
+$fz-list-bullet-illustration-string-l: $fz-xl * 2 !default;
+$lh-list-bullet-illustration-string-l: $lh-xxl * 2 !default;
+$mb-list-bullet-responsive-block-text: $m-xxxl * 2 !default;
 
 .sui-ListBullet {
   $prefix: &;
 
-  &--responsive {
+  &--responsive,
+  &--responsiveBlock {
     @include media-breakpoint-up(l) {
       display: flex;
 
@@ -32,6 +36,27 @@ $sz-list-bullet-illustration-l: 72px !default;
         margin-right: 0;
         width: $sz-list-bullet-illustration-l;
       }
+    }
+  }
+
+  &--responsiveBlock {
+    #{$prefix}-item {
+      flex: 1;
+      flex-direction: column;
+      margin: 0 $m-m;
+      text-align: center;
+    }
+
+    #{$prefix}-illustration {
+      height: $sz-list-bullet-illustration-l;
+      margin-bottom: $m-xl;
+      margin-right: 0;
+      width: $sz-list-bullet-illustration-l;
+    }
+
+    #{$prefix}-text {
+      font-size: $fz-m;
+      margin-bottom: $mb-list-bullet-responsive-block-text;
     }
   }
 
@@ -60,6 +85,13 @@ $sz-list-bullet-illustration-l: 72px !default;
     height: $sz-list-bullet-illustration-s;
     margin-right: $m-l;
     width: $sz-list-bullet-illustration-s;
+  }
+
+  &-illustrationString {
+    color: $c-primary;
+    font-size: $fz-list-bullet-illustration-string-l;
+    line-height: $lh-list-bullet-illustration-string-l;
+    margin: 0 0 $m-l;
   }
 
   &-title {

--- a/demo/list/bullet/playground
+++ b/demo/list/bullet/playground
@@ -18,11 +18,40 @@ const listItems = [
   }
 ]
 
+const listNumbersItems = [
+  {
+    illustration: '70%',
+    title: '',
+    text: 'de los compradores sólo visita coches.net'
+  },
+  {
+    illustration: '+18M',
+    title: '',
+    text: 'visitas mensuales a las que impactar'
+  },
+  {
+    illustration: 'x18',
+    title: '',
+    text: 'veces más tiempo de uso frente a otros portales'
+  }
+]
+
 return (
   <div>
-    <h2>Standard</h2>
-    <ListBullet listItems={listItems}/>
-    <h2>Responsive</h2>
-    <ListBullet listItems={listItems} responsive />
+    <div style={{marginBottom: "80px", padding: "20px"}}>
+      <h2 style={{marginBottom: "20px"}}>Standard</h2>
+      <ListBullet listItems={listItems}/>
+    </div>
+    
+    <div style={{marginBottom: "80px", padding: "20px"}}>
+      <h2 style={{marginBottom: "20px"}}>Responsive</h2>
+      <ListBullet listItems={listItems} responsive='responsive' />
+    </div>
+    
+    <div style={{marginBottom: "80px", padding: "20px"}}>
+      <h2 style={{marginBottom: "20px"}}>Responsive Block</h2>
+      <ListBullet listItems={listNumbersItems} isString responsive='responsiveBlock' />
+    </div>
+    
   </div>
 )


### PR DESCRIPTION
# In this Pull Request

## We need a component like this

### Mobile version

<img width="370" alt="mobile" src="https://user-images.githubusercontent.com/1307927/80127562-cbdaf580-8594-11ea-81c3-bfd9e69c019a.png">


### Desktop version

![desktop](https://user-images.githubusercontent.com/1307927/80127644-ec0ab480-8594-11ea-8228-2160e711de74.png)

## Changes

This component has a responsive behavior and we need to add a new behavior for the new design, so we applied the necessary changes to get the new layout in the mobile version and maintain the compatibility, **the changes needs to update the component on Baller Landing** because we are changing the **BOOLEAN prop** `responsive`  to **STRING prop** `responsive='responsive'`

## Demo

### Mobile version

<img width="540" alt="mobile-new" src="https://user-images.githubusercontent.com/1307927/80128299-bc0fe100-8595-11ea-89ef-89005127e818.png">

### Desktop version

<img width="1220" alt="desktop-new" src="https://user-images.githubusercontent.com/1307927/80128317-c4681c00-8595-11ea-8483-7bebdf402175.png">

