### PR TITLE
feat(form/builder): request config & interceptor props rename

### DIFF
--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -20,8 +20,8 @@ const FormBuilder = ({
   initFields,
   onChange,
   onBlur,
+  responseInterceptor,
   requestInterceptor,
-  urlInterceptor,
   loader,
   fieldSize,
   errors,
@@ -51,8 +51,8 @@ const FormBuilder = ({
     const reducerWithRules = reducer(
       rules,
       formID,
-      requestInterceptor,
-      urlInterceptor
+      responseInterceptor,
+      requestInterceptor
     )
     const timerShowSpinner = setTimeout(
       () => setStateShowSpinner(true),
@@ -81,8 +81,8 @@ const FormBuilder = ({
     const reducerWithRules = reducer(
       rules,
       formID,
-      requestInterceptor,
-      urlInterceptor
+      responseInterceptor,
+      requestInterceptor
     )
     const timerShowSpinner = setTimeout(
       () => setStateShowSpinner(true),
@@ -140,8 +140,8 @@ FormBuilder.propTypes = {
   json,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
+  responseInterceptor: PropTypes.func,
   requestInterceptor: PropTypes.func,
-  urlInterceptor: PropTypes.func,
   loader: PropTypes.object,
   fieldSize: PropTypes.oneOf(Object.values(fieldSizes)),
   errors: PropTypes.object,
@@ -152,8 +152,8 @@ FormBuilder.defaultProps = {
   initFields: {},
   onChange: () => {},
   onBlur: () => {},
-  requestInterceptor: ({response}) => response,
-  urlInterceptor: () => {},
+  responseInterceptor: ({response}) => response,
+  requestInterceptor: () => {},
   errors: {},
   alerts: {}
 }

--- a/components/form/builder/src/reducer/index.js
+++ b/components/form/builder/src/reducer/index.js
@@ -4,8 +4,8 @@ import {RULES} from './constants'
 export const reducer = (
   rules,
   formID,
-  requestInterceptor,
-  urlInterceptor
+  responseInterceptor,
+  requestInterceptor
 ) => async (fields, action) => {
   const {type, id} = action
   let nextFields
@@ -16,8 +16,8 @@ export const reducer = (
         rules,
         id,
         formID,
-        requestInterceptor,
-        urlInterceptor
+        responseInterceptor,
+        requestInterceptor
       )
       return nextFields
     default:


### PR DESCRIPTION
### BREAKING CHANGE
**Renamed interceptor props**
`urlInterceptor` to `requestInterceptor`
`requestInterceptor` to `responseInterceptor`

### GOAL
**Request config** (_with requestInterceptor_)
From the need in `coches` to make the requests with a `tenant` in the request headers to differentiate in `coches` and in `motos`, we apply this change to be able to fetch a configuration object (following the **Axios** pattern) and to be able to make the requests with headers if necessary.

<img width="709" alt="Captura de pantalla 2020-04-28 a las 12 06 58" src="https://user-images.githubusercontent.com/31726966/80475236-e0c6d880-8948-11ea-8601-8a6839691a2e.png">
