### PR TITLE
fix(react/hooks): fix useMediaQuery mismatch

### DIFF
--- a/components/react/hooks/README.md
+++ b/components/react/hooks/README.md
@@ -154,6 +154,19 @@ export default function Demo() {
 }
 ```
 
+**On the server, by default, the mediaQuery doesn't match** but you could pass an option to change this.
+
+```js
+import {useMediaQuery} from '@s-ui/react-hooks'
+
+export default function Demo() {
+  const isMatching = useMediaQuery('(min-width:600px)', { defaultMatches: true});
+  return <span>{`(min-width:600px) matches: ${isMatching}`}</span>;
+}
+```
+
+Keep in mind this functionality if you want to prioritize one design over other. For example, to be sure you render on the server the mobile layout and keep for the client.
+
 ### useScroll
 
 Hook to get the scroll position and the direction of scroll, limited to the Y axis.

--- a/components/react/hooks/src/useMediaQuery/index.js
+++ b/components/react/hooks/src/useMediaQuery/index.js
@@ -1,16 +1,13 @@
 import {useState, useEffect} from 'react'
 
-function useMediaQuery(queryInput) {
+const supportMatchMedia =
+  typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined'
+
+function useMediaQuery(queryInput, {defaultMatches = false} = {}) {
   const query = queryInput.replace(/^@media( ?)/m, '')
-  const supportMatchMedia =
-    typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined'
-  const defaultMatches = false
   const matchMedia = supportMatchMedia ? window.matchMedia : null
 
-  const [match, setMatch] = useState(() => {
-    if (supportMatchMedia) return matchMedia(query).matches
-    return defaultMatches
-  })
+  const [match, setMatch] = useState(defaultMatches)
 
   useEffect(() => {
     let active = true
@@ -28,7 +25,7 @@ function useMediaQuery(queryInput) {
       active = false
       queryList.removeListener(updateMatch)
     }
-  }, [query, matchMedia, supportMatchMedia])
+  }, [query, matchMedia])
 
   return match
 }


### PR DESCRIPTION
`useMediaQuery` is causing mismatches as the initial state of the hook could be different on server and client.

![image](https://user-images.githubusercontent.com/1561955/81148718-112bf980-8f7d-11ea-99a6-b3a204ae1d6a.png)

In order to fix this, instead using the initial value of the state, we're relying on the effect to change the state.

Also, we're adding a new feature to pass an object with options. In these options you could define the default value of the match, in order to do the same in the server and the client. By default it behaves equally as before.