### PR TITLE
fix(form/builder): fix onChange behaviour

### DIFF
--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -67,7 +67,7 @@ const FormBuilder = ({
     clearTimeout(timerShowSpinner)
     setStateFields(nextStateFields)
     onChange({
-      ...fieldsToObject(nextFields),
+      ...fieldsToObject(nextStateFields),
       __FIELD_CHANGED__: id
     })
     setStateShowSpinner(false)

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -40,10 +40,7 @@ const FormBuilder = ({
       {value: fieldValue}
     )
     setStateFields(nextFields)
-    onChange({
-      ...fieldsToObject(nextFields),
-      __FIELD_CHANGED__: fieldId
-    })
+
     return nextFields
   }
 
@@ -69,6 +66,10 @@ const FormBuilder = ({
 
     clearTimeout(timerShowSpinner)
     setStateFields(nextStateFields)
+    onChange({
+      ...fieldsToObject(nextFields),
+      __FIELD_CHANGED__: id
+    })
     setStateShowSpinner(false)
   }, []) // eslint-disable-line
 


### PR DESCRIPTION
### GOAL
When using version 2 of **FormBuilder** on the platform to test the **JSON** (workbench), an unexpected behavior has been observed, since it does not launch the **onChange** method at the expected time.
In one of the last commits, a duplicate call to the **onChange** method was removed, but it was found that the other one worked correctly, so the change was made.