### PR TITLE
feat(form/builder): customize sui components via JS

### DIFF
--- a/components/form/builder/src/Checkbox/index.js
+++ b/components/form/builder/src/Checkbox/index.js
@@ -5,7 +5,15 @@ import {field, createComponentMemo} from '../prop-types'
 import MoleculeCheckboxField from '@s-ui/react-molecule-checkbox-field'
 import IconCheck from '../Icons/IconCheck'
 
-const Checkbox = ({checkbox, tabIndex, onChange, onBlur, errors, alerts}) => {
+const Checkbox = ({
+  checkbox,
+  tabIndex,
+  onChange,
+  onBlur,
+  errors,
+  alerts,
+  renderer
+}) => {
   const errorMessages = errors[checkbox.id]
   const alertMessages = alerts[checkbox.id]
 
@@ -62,12 +70,24 @@ const Checkbox = ({checkbox, tabIndex, onChange, onBlur, errors, alerts}) => {
   if (checkboxProps.hidden) {
     return null
   }
+
+  const rendererResponse = renderer({
+    id: checkbox.id,
+    innerProps: checkboxProps
+  })
+
+  // render custom component
+  if (React.isValidElement(rendererResponse)) {
+    return rendererResponse
+  }
+
+  // render SUI component
   return (
     <div
       className={`sui-FormBuilder-field sui-FormBuilder-Switch sui-FormBuilder-${checkboxProps.id ||
         tabIndex}`}
     >
-      <MoleculeCheckboxField {...checkboxProps} />
+      <MoleculeCheckboxField {...checkboxProps} {...rendererResponse} />
     </div>
   )
 }
@@ -79,7 +99,8 @@ Checkbox.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default React.memo(Checkbox, createComponentMemo('checkbox'))

--- a/components/form/builder/src/FieldSet/index.js
+++ b/components/form/builder/src/FieldSet/index.js
@@ -14,7 +14,8 @@ const FieldSet = ({
   onBlur,
   fieldSize,
   errors,
-  alerts
+  alerts,
+  renderer
 }) => {
   const {fields = [], label} = fieldset
 
@@ -40,6 +41,7 @@ const FieldSet = ({
             fieldSize={fieldSize}
             errors={errors}
             alerts={alerts}
+            renderer={renderer}
           />
         ))}
       </div>
@@ -55,7 +57,8 @@ FieldSet.propTypes = {
   tabIndex: PropTypes.number,
   fieldSize: PropTypes.string,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default FieldSet

--- a/components/form/builder/src/InlineButton/index.js
+++ b/components/form/builder/src/InlineButton/index.js
@@ -5,9 +5,17 @@ import {field, createComponentMemo} from '../prop-types'
 import MoleculeButtonGroupField from '@s-ui/react-molecule-button-group-field'
 import Button from '@s-ui/react-atom-button'
 
-const InlineButton = ({inlineButton, tabIndex, onChange, errors, alerts}) => {
+const InlineButton = ({
+  inlineButton,
+  tabIndex,
+  onChange,
+  errors,
+  alerts,
+  renderer
+}) => {
   const errorMessages = errors[inlineButton.id]
   const alertMessages = alerts[inlineButton.id]
+  const datalist = inlineButton.datalist
 
   const onClickHandler = value => {
     return onChange(inlineButton.id, value)
@@ -35,13 +43,22 @@ const InlineButton = ({inlineButton, tabIndex, onChange, errors, alerts}) => {
     return null
   }
 
+  const rendererResponse = renderer({
+    id: inlineButton.id,
+    innerProps: {...inlineButtonProps, datalist}
+  })
+
+  // render custom component
+  if (React.isValidElement(rendererResponse)) return rendererResponse
+
+  // render SUI component
   return (
     <div
       className={`sui-FormBuilder-field sui-FormBuilder-InlineButton sui-FormBuilder-${inlineButtonProps.id ||
         tabIndex}`}
     >
-      <MoleculeButtonGroupField {...inlineButtonProps}>
-        {inlineButton?.datalist.map(button => (
+      <MoleculeButtonGroupField {...inlineButtonProps} {...rendererResponse}>
+        {datalist.map(button => (
           <Button
             key={button.text}
             design={button.value === inlineButton.value ? 'solid' : 'outline'}
@@ -63,7 +80,8 @@ InlineButton.propTypes = {
   tabIndex: PropTypes.number,
   onChange: PropTypes.func,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default React.memo(InlineButton, createComponentMemo('inlineButton'))

--- a/components/form/builder/src/Input/index.js
+++ b/components/form/builder/src/Input/index.js
@@ -29,7 +29,8 @@ const Input = ({
   leftAddon,
   rightAddon,
   errors,
-  alerts
+  alerts,
+  renderer
 }) => {
   const errorMessages = errors[input.id]
   const alertMessages = alerts[input.id]
@@ -138,11 +139,17 @@ const Input = ({
     return null
   }
 
+  const rendererResponse = renderer({id: input.id, innerProps: inputProps})
+
+  // render custom component
+  if (React.isValidElement(rendererResponse)) return rendererResponse
+
+  // render SUI component
   return (
     <div
       className={`sui-FormBuilder-field sui-FormBuilder-Input sui-FormBuilder-${inputProps.id}`}
     >
-      <MoleculeInputField {...inputProps} />
+      <MoleculeInputField {...inputProps} {...rendererResponse} />
     </div>
   )
 }
@@ -157,7 +164,8 @@ Input.propTypes = {
   leftAddon: PropTypes.string,
   rightAddon: PropTypes.string,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default React.memo(Input, createComponentMemo('input'))

--- a/components/form/builder/src/ProxyField/index.js
+++ b/components/form/builder/src/ProxyField/index.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import PropTypes from 'prop-types'
 import {field} from '../prop-types'
 
@@ -18,32 +16,71 @@ const ProxyField = ({
   onBlur,
   fieldSize,
   errors,
-  alerts
+  alerts,
+  renderer
 }) => {
   let Field
   switch (field.type) {
     case FIELDS.TEXT:
-      Field = TextField({field, tabIndex, onChange, onBlur, errors, alerts})
+      Field = TextField({
+        field,
+        tabIndex,
+        onChange,
+        onBlur,
+        errors,
+        alerts,
+        renderer
+      })
       break
 
     case FIELDS.NUMERIC:
-      Field = NumericField({field, tabIndex, onChange, onBlur, errors, alerts})
+      Field = NumericField({
+        field,
+        tabIndex,
+        onChange,
+        onBlur,
+        errors,
+        alerts,
+        renderer
+      })
       break
 
     case FIELDS.FIELDSET:
-      Field = FieldSetField({field, tabIndex, onChange, onBlur, errors, alerts})
+      Field = FieldSetField({
+        field,
+        tabIndex,
+        onChange,
+        onBlur,
+        errors,
+        alerts,
+        renderer
+      })
       break
 
     case FIELDS.PICKER:
-      Field = PickerField({field, tabIndex, onChange, onBlur, errors, alerts})
+      Field = PickerField({
+        field,
+        tabIndex,
+        onChange,
+        onBlur,
+        errors,
+        alerts,
+        renderer
+      })
       break
 
     default:
-      Field = (
-        <p>
-          Unknown Field type <span>{field.type}</span>
-        </p>
-      )
+      Field = renderer({
+        id: field.id,
+        innerProps: {
+          field,
+          tabIndex,
+          onChange,
+          onBlur,
+          errors,
+          alerts
+        }
+      })
   }
 
   return Field

--- a/components/form/builder/src/ProxyField/index.js
+++ b/components/form/builder/src/ProxyField/index.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import PropTypes from 'prop-types'
 import {field} from '../prop-types'
 
@@ -69,8 +70,8 @@ const ProxyField = ({
       })
       break
 
-    default:
-      Field = renderer({
+    default: {
+      const rendererResponse = renderer({
         id: field.id,
         innerProps: {
           field,
@@ -81,6 +82,17 @@ const ProxyField = ({
           alerts
         }
       })
+      if (React.isValidElement(rendererResponse)) {
+        Field = rendererResponse
+      } else {
+        Field = (
+          <p>
+            Unknown Field type <span>{field.type}</span>
+          </p>
+        )
+      }
+      break
+    }
   }
 
   return Field

--- a/components/form/builder/src/Radio/index.js
+++ b/components/form/builder/src/Radio/index.js
@@ -5,10 +5,10 @@ import {field, createComponentMemo} from '../prop-types'
 import MoleculeRadioButtonGroup from '@s-ui/react-molecule-radio-button-group'
 import MoleculeRadioButtonField from '@s-ui/react-molecule-radio-button-field'
 
-const Radio = ({radio, tabIndex, onChange, errors, alerts}) => {
+const Radio = ({radio, tabIndex, onChange, errors, alerts, renderer}) => {
   const errorMessages = errors[radio.id]
   const alertMessages = alerts[radio.id]
-
+  const datalist = radio.datalist
   const onChangeHandler = value => {
     return onChange(radio.id, value)
   }
@@ -35,6 +35,18 @@ const Radio = ({radio, tabIndex, onChange, errors, alerts}) => {
     return null
   }
 
+  const rendererResponse = renderer({
+    id: radio.id,
+    innerProps: {
+      ...radioProps,
+      datalist
+    }
+  })
+
+  // render custom component
+  if (React.isValidElement(rendererResponse)) return rendererResponse
+
+  // render SUI component
   return (
     <div
       className={`sui-FormBuilder-field sui-FormBuilder-Radio sui-FormBuilder-${radioProps.id ||
@@ -46,8 +58,9 @@ const Radio = ({radio, tabIndex, onChange, errors, alerts}) => {
         }}
         id={radio.id}
         value={radio.value}
+        {...rendererResponse}
       >
-        {radio?.datalist.map(button => (
+        {datalist.map(button => (
           <MoleculeRadioButtonField
             id={button.value}
             key={button.value}
@@ -67,7 +80,8 @@ Radio.propTypes = {
   tabIndex: PropTypes.number,
   onChange: PropTypes.func,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default React.memo(Radio, createComponentMemo('radio'))

--- a/components/form/builder/src/Select/Autosuggest/index.js
+++ b/components/form/builder/src/Select/Autosuggest/index.js
@@ -27,7 +27,8 @@ const AutosuggestSelect = ({
   onBlur,
   size,
   errors,
-  alerts
+  alerts,
+  renderer
 }) => {
   const errorMessages = errors[select.id]
   const alertMessages = alerts[select.id]
@@ -106,6 +107,15 @@ const AutosuggestSelect = ({
       )
     : datalist
 
+  const rendererResponse = renderer({
+    id: select.id,
+    innerProps: {...autosuggestProps, datalist}
+  })
+
+  // render custom component
+  if (React.isValidElement(rendererResponse)) return rendererResponse
+
+  // render SUI component
   return (
     <div
       className={`sui-FormBuilder-field sui-FormBuilder-AutosuggestSelect sui-FormBuilder-${autosuggestProps.id}`}
@@ -115,7 +125,7 @@ const AutosuggestSelect = ({
           {autosuggestProps.label}
         </label>
       )}
-      <MoleculeAutosuggestField {...autosuggestProps} size="large">
+      <MoleculeAutosuggestField {...autosuggestProps} {...rendererResponse}>
         {suggestions.map((suggestion, i) => (
           <MoleculeAutosuggestOption
             key={suggestion.value}
@@ -137,7 +147,8 @@ AutosuggestSelect.propTypes = {
   onBlur: PropTypes.func,
   size: PropTypes.string,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default React.memo(AutosuggestSelect, createComponentMemo('select'))

--- a/components/form/builder/src/Select/Default/index.js
+++ b/components/form/builder/src/Select/Default/index.js
@@ -14,7 +14,8 @@ const DefaultSelect = ({
   onBlur,
   size,
   errors,
-  alerts
+  alerts,
+  renderer
 }) => {
   const errorMessages = errors[select.id]
   const alertMessages = alerts[select.id]
@@ -74,6 +75,15 @@ const DefaultSelect = ({
     return null
   }
 
+  const rendererResponse = renderer({
+    id: select.id,
+    innerProps: {...selectProps, datalist}
+  })
+
+  // render custom component
+  if (React.isValidElement(rendererResponse)) return rendererResponse
+
+  // render SUI component
   return (
     <div
       className={`sui-FormBuilder-field sui-FormBuilder-DefaultSelect sui-FormBuilder-${selectProps.id}`}
@@ -83,7 +93,7 @@ const DefaultSelect = ({
           {selectProps.label}
         </label>
       )}
-      <MoleculeSelectField {...selectProps} size="large">
+      <MoleculeSelectField {...selectProps} {...rendererResponse}>
         {datalist.map(data => (
           <MoleculeSelectOption key={data.value} value={data.value}>
             {data.text}
@@ -102,7 +112,8 @@ DefaultSelect.propTypes = {
   onBlur: PropTypes.func,
   size: PropTypes.string,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default React.memo(DefaultSelect, createComponentMemo('select'))

--- a/components/form/builder/src/Select/index.js
+++ b/components/form/builder/src/Select/index.js
@@ -8,7 +8,16 @@ import {FIELDS, DISPLAYS} from '../Standard'
 import DefaultSelect from './Default'
 import AutosuggestSelect from './Autosuggest'
 
-const Select = ({select, onChange, onBlur, tabIndex, size, errors, alerts}) => {
+const Select = ({
+  select,
+  onChange,
+  onBlur,
+  tabIndex,
+  size,
+  errors,
+  alerts,
+  renderer
+}) => {
   let Field
   switch (select.display) {
     case DISPLAYS[FIELDS.PICKER].AUTOCOMPLETE:
@@ -21,6 +30,7 @@ const Select = ({select, onChange, onBlur, tabIndex, size, errors, alerts}) => {
           size={size}
           errors={errors}
           alerts={alerts}
+          renderer={renderer}
         />
       )
       break
@@ -36,6 +46,7 @@ const Select = ({select, onChange, onBlur, tabIndex, size, errors, alerts}) => {
           size={size}
           errors={errors}
           alerts={alerts}
+          renderer={renderer}
         />
       )
   }
@@ -50,7 +61,8 @@ Select.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default Select

--- a/components/form/builder/src/Standard/Fields/FieldSet/index.js
+++ b/components/form/builder/src/Standard/Fields/FieldSet/index.js
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types'
 
 import FieldSet from '../../../FieldSet'
 
-const FieldSetField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
+const FieldSetField = ({
+  field,
+  tabIndex,
+  onChange,
+  onBlur,
+  errors,
+  alerts,
+  renderer
+}) => {
   return (
     <FieldSet
       fieldset={field}
@@ -12,6 +20,7 @@ const FieldSetField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
       tabIndex={tabIndex}
       errors={errors}
       alerts={alerts}
+      renderer={renderer}
     />
   )
 }
@@ -22,7 +31,8 @@ FieldSetField.propTypes = {
   tabIndex: PropTypes.number,
   field: PropTypes.object,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default FieldSetField

--- a/components/form/builder/src/Standard/Fields/Numeric/index.js
+++ b/components/form/builder/src/Standard/Fields/Numeric/index.js
@@ -5,7 +5,15 @@ import Input from '../../../Input'
 
 import {FIELDS, DISPLAYS} from '../../index'
 
-const NumericField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
+const NumericField = ({
+  field,
+  tabIndex,
+  onChange,
+  onBlur,
+  errors,
+  alerts,
+  renderer
+}) => {
   /* TODO: add the possibility to customize rightAddon in the DSL */
   if (field.display === DISPLAYS[FIELDS.NUMERIC].MONEY) {
     return (
@@ -14,9 +22,9 @@ const NumericField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         onChange={onChange}
         onBlur={onBlur}
         tabIndex={tabIndex}
-        rightAddon="€"
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   } else {
@@ -28,6 +36,7 @@ const NumericField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         tabIndex={tabIndex}
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   }
@@ -38,7 +47,8 @@ NumericField.propTypes = {
   tabIndex: PropTypes.number,
   field: PropTypes.object,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default NumericField

--- a/components/form/builder/src/Standard/Fields/Picker/index.js
+++ b/components/form/builder/src/Standard/Fields/Picker/index.js
@@ -9,7 +9,15 @@ import Radio from '../../../Radio'
 
 import {FIELDS, DISPLAYS} from '../../index'
 
-const PickerField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
+const PickerField = ({
+  field,
+  tabIndex,
+  onChange,
+  onBlur,
+  errors,
+  alerts,
+  renderer
+}) => {
   if (field.display === DISPLAYS[FIELDS.PICKER].SWITCH) {
     return (
       <Switch
@@ -19,6 +27,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         tabIndex={tabIndex}
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   } else if (
@@ -33,6 +42,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         tabIndex={tabIndex}
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   } else if (field.display === DISPLAYS[FIELDS.PICKER].RADIO) {
@@ -44,6 +54,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         tabIndex={tabIndex}
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   } else if (field.display === DISPLAYS[FIELDS.PICKER].CHECKBOX) {
@@ -55,6 +66,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         tabIndex={tabIndex}
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   } else if (field.display === DISPLAYS[FIELDS.PICKER].BUTTON_INLINE) {
@@ -66,6 +78,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         tabIndex={tabIndex}
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   } else {
@@ -78,6 +91,7 @@ const PickerField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         tabIndex={tabIndex}
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   }
@@ -89,7 +103,8 @@ PickerField.propTypes = {
   tabIndex: PropTypes.number,
   field: PropTypes.object,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default PickerField

--- a/components/form/builder/src/Standard/Fields/Text/index.js
+++ b/components/form/builder/src/Standard/Fields/Text/index.js
@@ -6,7 +6,15 @@ import TextArea from '../../../TextArea'
 
 import {FIELDS, DISPLAYS} from '../../index'
 
-const TextField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
+const TextField = ({
+  field,
+  tabIndex,
+  onChange,
+  onBlur,
+  errors,
+  alerts,
+  renderer
+}) => {
   if (field.display === DISPLAYS[FIELDS.TEXT].MULTILINE)
     return (
       <TextArea
@@ -16,6 +24,7 @@ const TextField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
         tabIndex={tabIndex}
         errors={errors}
         alerts={alerts}
+        renderer={renderer}
       />
     )
   return (
@@ -26,6 +35,7 @@ const TextField = ({field, tabIndex, onChange, onBlur, errors, alerts}) => {
       tabIndex={tabIndex}
       errors={errors}
       alerts={alerts}
+      renderer={renderer}
     />
   )
 }
@@ -36,7 +46,8 @@ TextField.propTypes = {
   tabIndex: PropTypes.number,
   field: PropTypes.object,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default TextField

--- a/components/form/builder/src/Switch/index.js
+++ b/components/form/builder/src/Switch/index.js
@@ -4,7 +4,14 @@ import PropTypes from 'prop-types'
 import {field, createComponentMemo} from '../prop-types'
 import MoleculeSwitch from '@s-ui/react-atom-switch'
 
-const Switch = ({switchField, tabIndex, onChange, errors, alerts}) => {
+const Switch = ({
+  switchField,
+  tabIndex,
+  onChange,
+  errors,
+  alerts,
+  renderer
+}) => {
   const errorMessages = errors[switchField.id]
   const alertMessages = alerts[switchField.id]
 
@@ -14,10 +21,9 @@ const Switch = ({switchField, tabIndex, onChange, errors, alerts}) => {
     },
     [onChange, switchField]
   )
-  const {id} = switchField
 
   const switchProps = {
-    name: id,
+    name: switchField.id,
     label: switchField.label,
     labelLeft: 'NOP',
     labelRight: 'ZIP',
@@ -42,12 +48,20 @@ const Switch = ({switchField, tabIndex, onChange, errors, alerts}) => {
     return null
   }
 
+  const rendererResponse = renderer({
+    id: switchField.id,
+    innerProps: switchProps
+  })
+  // render custom component
+  if (React.isValidElement(rendererResponse)) return rendererResponse
+
+  // render SUI component
   return (
     <div
       className={`sui-FormBuilder-field sui-FormBuilder-Switch sui-FormBuilder-${switchProps.id ||
         tabIndex}`}
     >
-      <MoleculeSwitch {...switchProps} />
+      <MoleculeSwitch {...switchProps} {...rendererResponse} />
     </div>
   )
 }
@@ -58,7 +72,8 @@ Switch.propTypes = {
   switchField: field,
   onChange: PropTypes.func,
   errors: PropTypes.objects,
-  alerts: PropTypes.objects
+  alerts: PropTypes.objects,
+  renderer: PropTypes.func
 }
 
 export default React.memo(Switch, createComponentMemo('switchField'))

--- a/components/form/builder/src/TextArea/index.js
+++ b/components/form/builder/src/TextArea/index.js
@@ -5,7 +5,15 @@ import {field, createComponentMemo} from '../prop-types'
 
 import MoleculeTextAreaField from '@s-ui/react-molecule-textarea-field'
 
-const TextArea = ({textArea, tabIndex, onChange, onBlur, errors, alerts}) => {
+const TextArea = ({
+  textArea,
+  tabIndex,
+  onChange,
+  onBlur,
+  errors,
+  alerts,
+  renderer
+}) => {
   const errorMessages = errors[textArea.id]
   const alertMessages = alerts[textArea.id]
 
@@ -72,11 +80,20 @@ const TextArea = ({textArea, tabIndex, onChange, onBlur, errors, alerts}) => {
     return null
   }
 
+  const rendererResponse = renderer({
+    id: textArea.id,
+    innerProps: textAreaProps
+  })
+
+  // render custom component
+  if (React.isValidElement(rendererResponse)) return rendererResponse
+
+  // render SUI component
   return (
     <div
       className={`sui-FormBuilder-field sui-FormBuilder-TextArea sui-FormBuilder-${textAreaProps.id}`}
     >
-      <MoleculeTextAreaField {...textAreaProps} size="long" />
+      <MoleculeTextAreaField {...textAreaProps} {...rendererResponse} />
     </div>
   )
 }
@@ -88,7 +105,8 @@ TextArea.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
 }
 
 export default React.memo(TextArea, createComponentMemo('textArea'))

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -25,7 +25,8 @@ const FormBuilder = ({
   loader,
   fieldSize,
   errors,
-  alerts
+  alerts,
+  children: renderer
 }) => {
   const {fields = [], rules = {}, id: formID} = json.form
   const [stateFields, setStateFields] = useState(fields)
@@ -119,6 +120,7 @@ const FormBuilder = ({
           fieldSize={fieldSize}
           errors={errors}
           alerts={alerts}
+          renderer={renderer}
         />
       ))}
       {stateShowSpinner && (
@@ -141,7 +143,8 @@ FormBuilder.propTypes = {
   loader: PropTypes.object,
   fieldSize: PropTypes.oneOf(Object.values(fieldSizes)),
   errors: PropTypes.object,
-  alerts: PropTypes.object
+  alerts: PropTypes.object,
+  children: PropTypes.func
 }
 
 FormBuilder.defaultProps = {
@@ -151,7 +154,8 @@ FormBuilder.defaultProps = {
   responseInterceptor: ({response}) => response,
   requestInterceptor: () => {},
   errors: {},
-  alerts: {}
+  alerts: {},
+  children: () => ({})
 }
 
 export {fieldSizes as formBuilderFieldSizes}


### PR DESCRIPTION
#### Description
Add **children** prop, that should be a function (called renderer inside form builder) that receives two arguments: id and innerProps. 

If this function returns: 
- A `component` it will be rendered [instead](https://github.com/SUI-Components/adevinta-spain-components/pull/233/files#diff-5831da6776fc2aa1c60a4984599677d3R80) of the sui-component.
- A plain JS `object`, this object will be [passed as props of the sui-component](https://github.com/SUI-Components/adevinta-spain-components/pull/233/files#diff-5831da6776fc2aa1c60a4984599677d3R90).

Example:

```js
<FormBuilder
                  json={JSONBuilder}
                  onChange={fields => updateFields(fields)}
                  onBlur={onBlur}
                  errors={errors}
                >
                  {({id, innerProps}) => {
                    const props = {
                      color: {
                        size: 'large'
                      }
                    }
                    return props[id]
                  }}
</FormBuilder>
```
In this example the field with ID color will render the component defined in the JSON with size="large".

#### BREAKING CHANGE:
remove hardcoded values like size="long" inside some components.

#### MIGRATING GUIDE:
- If you are using a type="picker" with display="" (default) or display="dropdown" or display="autosuggest" the size of select sui component will no longer be large by default and you need to pass it as explained in the example. [Code removed](https://github.com/SUI-Components/adevinta-spain-components/pull/233/files#diff-4107bf78a3f3e980a181a6e1c7d4e5a1L86)
- If you are using a type="numeric" with display="money" the rightAddon will be empty by default and you will need to pass it as explained in the example [Code removed](https://github.com/SUI-Components/adevinta-spain-components/pull/233/files#diff-d1c5de68dcbc3d4a8180c327352aebf7L17)
- If you are using a type="text" with display="multiline" the size will be empty by default and you will need to pass it as explained in the example [Code removed](https://github.com/SUI-Components/adevinta-spain-components/pull/233/files#diff-2ae6c39f35e097c4a5db5e7f4bb944cdL79)
