### PR TITLE
fix(form/builder): avoid breaking if value is not 'true' or 'false'

### DIFF
--- a/components/form/builder/src/Standard/index.js
+++ b/components/form/builder/src/Standard/index.js
@@ -103,7 +103,7 @@ const checkConstraintsFromField = field => {
     field.type === FIELDS.PICKER &&
     field.display === DISPLAYS[FIELDS.PICKER].CHECKBOX
   ) {
-    const checkboxValue = JSON.parse(elementNode?.value)
+    const checkboxValue = elementNode?.value === 'true'
 
     const checkboxShouldBeTrueConstraint = field.constraints?.find(
       constraint => constraint.property?.pattern === '^true$'


### PR DESCRIPTION
`JSON.parse` breaks if argument is not parseable, so if it is 'true' resolve as a true and everything else resolve to false and avoid breaking.