### PR TITLE
feat(abtesting/hooks): add forceExperiment browser query flag

### DIFF
--- a/components/abtesting/optimizelyXExperiment/README.md
+++ b/components/abtesting/optimizelyXExperiment/README.md
@@ -183,6 +183,15 @@ This prop is similar to `forceVariation` prop, but it simulates an actual activa
 
 In the above example, "Cats" variation will be displayed first, then after a few milliseconds "Dogs" variation will be definitely displayed. You can also use variation name instead:
 
+```js
+<OptimizelyXExperiment experimentId={8470306415} forceActivation="B">
+  <button variationId={8463707014} defaultVariation>Cats</button>
+  <button variationId={8480321136}>Dogs</button>
+</OptimizelyXExperiment>
+```
+
+NOTE: Since this prop is meant to be used in development environment only, `forceActivation` is just ignored in production as a preventive measure.
+
 ### forceExperiment — The Query Param
 
 Wanna take a quick look into a variation? You can add `forceExperiment` query param to the URL on the address bar, providing experiment name and variation you want to activate as a value:

--- a/components/abtesting/optimizelyXExperiment/README.md
+++ b/components/abtesting/optimizelyXExperiment/README.md
@@ -183,14 +183,22 @@ This prop is similar to `forceVariation` prop, but it simulates an actual activa
 
 In the above example, "Cats" variation will be displayed first, then after a few milliseconds "Dogs" variation will be definitely displayed. You can also use variation name instead:
 
-```js
-<OptimizelyXExperiment experimentId={8470306415} forceActivation="B">
-  <button variationId={8463707014} defaultVariation>Cats</button>
-  <button variationId={8480321136}>Dogs</button>
-</OptimizelyXExperiment>
+### forceExperiment — The Query Param
+
+Wanna take a quick look into a variation? You can add `forceExperiment` query param to the URL on the address bar, providing experiment name and variation you want to activate as a value:
+
+```
+?forceExperiment=<experiment-name>|<variation-name>
 ```
 
-NOTE: Since this prop is meant to be used in development environment only, `forceActivation` is just ignored in production as a preventive measure.
+For example, an experiment whose name is `myexperiment` with a `biggerButton` variation would look like this:
+```
+?forceExperiment=myexperiment|biggerButton
+```
+
+Note that this gets stored into the session storage, so the variation will show up through the entire navigation process until the tab gets closed. This is intended to avoid unnecessarily repeating the process of adding the mentioned query param.
+
+This way, UX or other roles can check variations whenever they like without the need of setting up and publishing the AB Test on Optimizely Panel, which is slower, cumbersome and wastes traffic from the plan.
 
 ## Known issues
 


### PR DESCRIPTION
# Add forceExperiment browser query flag

Now that we can give names to experiments, it's easy to provide extra methods of fake activation out of the code scope.

This way, UX or other roles can check variations whenever they like without the need of setting up and publishing the AB Test on Optimizely Panel, which is slower, cumbersome and wastes traffic from the plan.

### How does it work?

Simply add the `forceExperiment` query param to the URL on the address bar, providing experiment name and variation you want to activate as a value:
```
?forceExperiment=<experiment-name>|<variation-name>
```

For example, an experiment whose name is `myexperiment` with a `biggerButton` variation would look like this:
```
?forceExperiment=myexperiment|biggerButton
```

Note that this gets stored into the session storage, so the variation will show up through the entire navigation process until the tab gets closed. This is intended to avoid unnecessarily repeating the process of adding the mentioned query param.