### PR TITLE
feat(abtesting/hooks): sequence of activations force experiment query…

### DIFF
--- a/components/abtesting/hooks/src/useExperimentCore/index.js
+++ b/components/abtesting/hooks/src/useExperimentCore/index.js
@@ -164,8 +164,9 @@ export default params => {
           // so it can override session storage entry.
           const [nameFromQP] = splitNames(forceExperimentFromQueryParam)
           const [nameFromSS] = splitNames(forceExperimentFromSessionStorage)
-          if (nameFromQP === nameFromSS) return forceExperimentFromQueryParam
-          return forceExperimentFromSessionStorage
+          return nameFromQP === nameFromSS
+            ? forceExperimentFromQueryParam
+            : forceExperimentFromSessionStorage
         }
         // Otherwise, whether any of them are present preference rule is simple
         return (

--- a/components/abtesting/hooks/src/useExperimentCore/index.js
+++ b/components/abtesting/hooks/src/useExperimentCore/index.js
@@ -146,14 +146,36 @@ export default params => {
      *   the tab session.
      */
     if (typeof URLSearchParams !== 'undefined') {
-      const SESSION_STORAGE_KEY = '_suiAbtestingForceExperiment'
+      const sessionStorageKey = `_suiAbtestingForceExperiment_${state.experimentId}`
       const urlParams = new URLSearchParams(window.location.search)
-      const forceExperiment =
-        urlParams.get('forceExperiment') ||
-        window.sessionStorage.getItem(SESSION_STORAGE_KEY)
+      const forceExperimentFromQueryParam = urlParams.get('forceExperiment')
+      const forceExperimentFromSessionStorage = window.sessionStorage.getItem(
+        sessionStorageKey
+      )
 
+      const splitNames = forceExperiment => forceExperiment.split('|')
+      const getForceExperimentToBeApplied = () => {
+        if (
+          forceExperimentFromQueryParam &&
+          forceExperimentFromSessionStorage
+        ) {
+          // When both query param and session storage entry are present,
+          // query param has preference BUT only if it's the same name,
+          // so it can override session storage entry.
+          const [nameFromQP] = splitNames(forceExperimentFromQueryParam)
+          const [nameFromSS] = splitNames(forceExperimentFromSessionStorage)
+          if (nameFromQP === nameFromSS) return forceExperimentFromQueryParam
+          return forceExperimentFromSessionStorage
+        }
+        // Otherwise, whether any of them are present preference rule is simple
+        return (
+          forceExperimentFromQueryParam || forceExperimentFromSessionStorage
+        )
+      }
+
+      const forceExperiment = getForceExperimentToBeApplied()
       if (forceExperiment) {
-        const [experimentName, variationName] = forceExperiment.split('|')
+        const [experimentName, variationName] = splitNames(forceExperiment)
         if (
           !experimentName ||
           !variationName ||
@@ -168,7 +190,7 @@ export default params => {
           forceActivationDelay
         )
 
-        window.sessionStorage.setItem(SESSION_STORAGE_KEY, forceExperiment)
+        window.sessionStorage.setItem(sessionStorageKey, forceExperiment)
         return
       }
     }


### PR DESCRIPTION
An improvement over #240 which enables the capability of accumulating multiple experiment activations by saving `forceExperiment` query param action to a unique session storage key.