### PR TITLE
fix(form/builder): fix typo on function and export

### DIFF
--- a/components/form/builder/src/Standard/index.js
+++ b/components/form/builder/src/Standard/index.js
@@ -145,4 +145,17 @@ const checkConstraintsFactory = json => ({for: fieldID, all}) => {
   return fieldsWithErrors
 }
 
-export {FIELDS, DISPLAYS, CONSTRAINTS, checkConstraintsFactory}
+const checkConstrainstsFactory = json => {
+  window.console.warn(
+    '[form/builder]: checkConstrainstsFactory should not be used and should be DEPRECATED in the next major release'
+  )
+  return checkConstraintsFactory(json)
+}
+
+export {
+  FIELDS,
+  DISPLAYS,
+  CONSTRAINTS,
+  checkConstraintsFactory,
+  checkConstrainstsFactory
+}

--- a/components/form/builder/src/Standard/index.js
+++ b/components/form/builder/src/Standard/index.js
@@ -117,11 +117,11 @@ const checkConstraintsFromField = field => {
   return errorMessages
 }
 
-const checkConstrainstsFactory = json => ({for: fieldID, all}) => {
+const checkConstraintsFactory = json => ({for: fieldID, all}) => {
   let fieldsToValidate = []
   if (all && fieldID) {
     window.console.warn(
-      '[form/builder]: checkConstrainstsFactory: both modes validate all fields and validate a concrete field are not compatible, please use one of them'
+      '[form/builder]: checkConstraintsFactory: both modes validate all fields and validate a concrete field are not compatible, please use one of them'
     )
   } else if (all) {
     fieldsToValidate = fieldsNamesInOrderOfDefinition(json?.form?.fields)
@@ -129,7 +129,7 @@ const checkConstrainstsFactory = json => ({for: fieldID, all}) => {
     fieldsToValidate = [fieldID]
   } else {
     window.console.warn(
-      '[form/builder]: checkConstrainstsFactory: Specify if you want to validate a specific field or all the fields'
+      '[form/builder]: checkConstraintsFactory: Specify if you want to validate a specific field or all the fields'
     )
   }
 
@@ -145,4 +145,4 @@ const checkConstrainstsFactory = json => ({for: fieldID, all}) => {
   return fieldsWithErrors
 }
 
-export {FIELDS, DISPLAYS, CONSTRAINTS, checkConstrainstsFactory}
+export {FIELDS, DISPLAYS, CONSTRAINTS, checkConstraintsFactory}

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -162,9 +162,5 @@ export {fieldSizes as formBuilderFieldSizes}
 export {pickFieldById as formBuilderPickFieldById}
 export {changeFieldById as formBuilderChangeFieldById}
 export {fieldsNamesInOrderOfDefinition as formBuilderFieldsNamesInOrderOfDefinition}
-export {
-  checkConstraintsFactory,
-  // WARNING do not use the following export, it is kept for backwards compatibility
-  checkConstrainstsFactory
-} from './Standard'
+export {checkConstraintsFactory, checkConstrainstsFactory} from './Standard'
 export default FormBuilder

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -165,6 +165,6 @@ export {fieldsNamesInOrderOfDefinition as formBuilderFieldsNamesInOrderOfDefinit
 export {
   checkConstraintsFactory,
   // WARNING do not use the following export, it is kept for backwards compatibility
-  checkConstraintsFactory as checkConstrainstsFactory
+  checkConstrainstsFactory
 } from './Standard'
 export default FormBuilder

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -162,5 +162,9 @@ export {fieldSizes as formBuilderFieldSizes}
 export {pickFieldById as formBuilderPickFieldById}
 export {changeFieldById as formBuilderChangeFieldById}
 export {fieldsNamesInOrderOfDefinition as formBuilderFieldsNamesInOrderOfDefinition}
-export {checkConstrainstsFactory} from './Standard'
+export {
+  checkConstraintsFactory,
+  // WARNING do not use the following export, it is kept for backwards compatibility
+  checkConstraintsFactory as checkConstrainstsFactory
+} from './Standard'
 export default FormBuilder


### PR DESCRIPTION
Fixes a function name containing a typo. Keeps backwards compatibility.