### PR TITLE
feat(list/link): use new @s-ui/react-link-basic

### DIFF
--- a/components/list/link/package.json
+++ b/components/list/link/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@schibstedspain/sui-link-basic": "1"
+    "@s-ui/react-link-basic": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/list/link/src/index.js
+++ b/components/list/link/src/index.js
@@ -2,26 +2,43 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
-import LinkBasic from '@schibstedspain/sui-link-basic'
+import LinkBasic from '@s-ui/react-link-basic'
+
+function ListLinkItem({displayInline, item, useReactRouterLinks}) {
+  const className = cx('sui-ListLink-item', {
+    'sui-ListLink-item--inline': displayInline
+  })
+
+  return (
+    <li className={className}>
+      <LinkBasic {...item} useReactRouterLinks={useReactRouterLinks} />
+    </li>
+  )
+}
+
+ListLinkItem.propTypes = {
+  displayInline: PropTypes.bool,
+  item: PropTypes.object,
+  useReactRouterLinks: PropTypes.bool
+}
 
 export default function ListLink({
   displayInline,
   list = [],
   useReactRouterLinks
 }) {
-  const renderLink = (item, index) => {
-    const classListItem = cx('sui-ListLink-item', {
-      'sui-ListLink-item--inline': displayInline
-    })
-
-    return (
-      <li className={classListItem} key={index}>
-        <LinkBasic {...item} useReactRouterLinks={useReactRouterLinks} />
-      </li>
-    )
-  }
-
-  return <ul className="sui-ListLink">{list.map(renderLink)}</ul>
+  return (
+    <ul className="sui-ListLink">
+      {list.map((item, index) => (
+        <ListLinkItem
+          key={index}
+          item={item}
+          displayInline={displayInline}
+          useReactRouterLinks={useReactRouterLinks}
+        />
+      ))}
+    </ul>
+  )
 }
 
 ListLink.displayName = 'ListLink'

--- a/components/list/link/src/index.scss
+++ b/components/list/link/src/index.scss
@@ -1,6 +1,6 @@
 @import '~@s-ui/theme/lib/settings-compat-v7/index';
 @import '~@s-ui/theme/lib/index';
-@import '~@schibstedspain/sui-link-basic/lib/index';
+@import '~@s-ui/react-link-basic/lib/index';
 
 $m-list-link-item-inline: $m-m;
 


### PR DESCRIPTION
Surprisingly, list link used the old version of link/basic. With this change we're using the latest compatible version.

So, I'm moving this in order to avoid installing two different packages for the same thing.

![image](https://user-images.githubusercontent.com/1561955/86609509-4d46ff00-bfac-11ea-86a3-d590cbd8bc59.png)