### PR TITLE
fix(tcf/firstLayer): do action before to parent unmount child

### DIFF
--- a/components/tcf/firstLayer/src/index.js
+++ b/components/tcf/firstLayer/src/index.js
@@ -7,7 +7,7 @@ import IconClose from './iconClose'
 import {I18N} from './settings'
 
 const CLASS = 'sui-TcfFirstLayer'
-// Adevinta rule of 250px of scroll to directly accept consent
+
 const SCROLL_TO_ACCEPT = 250
 
 export default function TcfFirstLayer({
@@ -104,9 +104,8 @@ export default function TcfFirstLayer({
     for (const key in VLSpecialFeatures) {
       specialFeatures[key] = true
     }
-
-    saveUserConsent(userConsent)
     handleCloseModal()
+    saveUserConsent(userConsent)
   }
 
   const handleCloseModal = () => {


### PR DESCRIPTION
## Description
Change the order of actions, to execute the handleCloseModal before that the parent (tcf ui) unmounts this component.
Also comment with Adevinta information is been removed

## Solves ticket/s
As a result of https://jira.scmspain.com/browse/PSP-3325

## Expected behavior
The UI component flow works correctly. All necessary actions are done before the unmounting

## Review steps
There is no change in this components demo, but the UI demo can be checked and there shouldn't be any console error.
