### PR TITLE
Feature/second layer iteration 2

### DIFF
--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
@@ -10,6 +10,9 @@ export default function TcfSecondLayerDecisionGroup({
   baseClass,
   descriptions,
   state,
+  filteredIds,
+  hasConsent,
+  hasLegitimateInterest,
   onConsentChange,
   onLegitimateInterestChange,
   onAcceptAll,
@@ -17,36 +20,50 @@ export default function TcfSecondLayerDecisionGroup({
   vendorList,
   expandedContent
 }) {
+  let descriptionKeys =
+    descriptions && Object.keys(descriptions).map(key => parseInt(key))
+  if (filteredIds) {
+    descriptionKeys = descriptionKeys.filter(key => filteredIds.includes(key))
+  }
+  if (!descriptionKeys?.length) {
+    return null
+  }
+
   return (
     <>
       <div className={`${baseClass}-title-container`}>
         <h2 className={`${baseClass}-title`}>{name}</h2>
-        <div className={`${baseClass}-buttons`}>
-          <SuiButton size="small" design="outline" onClick={onRejectAll}>
-            {i18n.DISABLE_BUTTON}
-          </SuiButton>
-          <SuiButton size="small" onClick={onAcceptAll}>
-            {i18n.ENABLE_BUTTON}
-          </SuiButton>
-        </div>
+        {hasConsent || hasLegitimateInterest ? (
+          <div className={`${baseClass}-buttons`}>
+            <SuiButton size="small" design="outline" onClick={onRejectAll}>
+              {i18n.DISABLE_BUTTON}
+            </SuiButton>
+            <SuiButton size="small" onClick={onAcceptAll}>
+              {i18n.ENABLE_BUTTON}
+            </SuiButton>
+          </div>
+        ) : null}
       </div>
-      {state &&
-        descriptions &&
-        Object.keys(descriptions).map((key, index) => {
-          return (
-            <TcfSecondLayerUserDecision
-              key={`${key}-${index}`}
-              baseClass={`${baseClass}-item`}
-              info={descriptions[key]}
-              consentValue={state.consents[key]}
-              hasLegitimateInterest={false}
-              i18n={i18n}
-              vendorList={vendorList}
-              onConsentChange={value => onConsentChange({index: key, value})}
-              expandedContent={expandedContent}
-            />
-          )
-        })}
+      {descriptionKeys.map((key, index) => {
+        return (
+          <TcfSecondLayerUserDecision
+            key={`${key}-${index}`}
+            baseClass={`${baseClass}-item`}
+            info={descriptions[key]}
+            consentValue={state?.consents?.[key]}
+            legitimateInterestValue={state?.legitimateInterestValue?.[key]}
+            hasConsent={hasConsent}
+            hasLegitimateInterest={hasLegitimateInterest}
+            i18n={i18n}
+            vendorList={vendorList}
+            onConsentChange={value => onConsentChange({index: key, value})}
+            onLegitimateInterestChange={value =>
+              onLegitimateInterestChange({index: key, value})
+            }
+            expandedContent={expandedContent}
+          />
+        )
+      })}
     </>
   )
 }
@@ -57,6 +74,9 @@ TcfSecondLayerDecisionGroup.propTypes = {
   baseClass: PropTypes.string,
   descriptions: PropTypes.object,
   state: PropTypes.object,
+  filteredIds: PropTypes.arrayOf(PropTypes.number),
+  hasConsent: PropTypes.bool,
+  hasLegitimateInterest: PropTypes.bool,
   onConsentChange: PropTypes.func,
   onLegitimateInterestChange: PropTypes.func,
   onAcceptAll: PropTypes.func,

--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
@@ -14,7 +14,8 @@ export default function TcfSecondLayerDecisionGroup({
   onLegitimateInterestChange,
   onAcceptAll,
   onRejectAll,
-  vendorList
+  vendorList,
+  expandedContent
 }) {
   return (
     <>
@@ -38,13 +39,11 @@ export default function TcfSecondLayerDecisionGroup({
               baseClass={`${baseClass}-item`}
               info={descriptions[key]}
               consentValue={state.consents[key]}
-              legitimateInterestValue={state.legitimateInterests[key]}
+              hasLegitimateInterest={false}
               i18n={i18n}
               vendorList={vendorList}
               onConsentChange={value => onConsentChange({index: key, value})}
-              onLegitimateInterestChange={value =>
-                onLegitimateInterestChange({index: key, value})
-              }
+              expandedContent={expandedContent}
             />
           )
         })}
@@ -62,5 +61,6 @@ TcfSecondLayerDecisionGroup.propTypes = {
   onLegitimateInterestChange: PropTypes.func,
   onAcceptAll: PropTypes.func,
   onRejectAll: PropTypes.func,
-  vendorList: PropTypes.object
+  vendorList: PropTypes.object,
+  expandedContent: PropTypes.func
 }

--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
@@ -45,9 +45,9 @@ export default function TcfSecondLayerDecisionGroup({
         ) : null}
       </div>
       {descriptionKeys.map((key, index) => {
-        const consentValue = !Array.isArray(state)
-          ? state?.consents?.[key]
-          : state?.includes(key)
+        const consentValue = state?.consents
+          ? state.consents[key]
+          : state?.[key]
         return (
           <TcfSecondLayerUserDecision
             key={`${key}-${index}`}

--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
@@ -45,12 +45,15 @@ export default function TcfSecondLayerDecisionGroup({
         ) : null}
       </div>
       {descriptionKeys.map((key, index) => {
+        const consentValue = !Array.isArray(state)
+          ? state?.consents?.[key]
+          : state?.includes(key)
         return (
           <TcfSecondLayerUserDecision
             key={`${key}-${index}`}
             baseClass={`${baseClass}-item`}
             info={descriptions[key]}
-            consentValue={state?.consents?.[key]}
+            consentValue={consentValue}
             legitimateInterestValue={state?.legitimateInterestValue?.[key]}
             hasConsent={hasConsent}
             hasLegitimateInterest={hasLegitimateInterest}

--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-legal-expandedContent/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-legal-expandedContent/index.js
@@ -1,10 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default function TcfSecondLayerPurposeExpandedContent({
-  baseClass,
-  info
-}) {
+export default function TcfSecondLayerLegalExpandedContent({baseClass, info}) {
   return (
     <>
       <h4>{info.description}</h4>
@@ -13,7 +10,7 @@ export default function TcfSecondLayerPurposeExpandedContent({
   )
 }
 
-TcfSecondLayerPurposeExpandedContent.propTypes = {
+TcfSecondLayerLegalExpandedContent.propTypes = {
   baseClass: PropTypes.string.isRequired,
   info: PropTypes.object.isRequired
 }

--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-purpose-expandedContent/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-purpose-expandedContent/index.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function TcfSecondLayerPurposeExpandedContent({
+  baseClass,
+  info
+}) {
+  return (
+    <>
+      <h4>{info.description}</h4>
+      <p>{info.descriptionLegal}</p>
+    </>
+  )
+}
+
+TcfSecondLayerPurposeExpandedContent.propTypes = {
+  baseClass: PropTypes.string.isRequired,
+  info: PropTypes.object.isRequired
+}

--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-user-decision/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-user-decision/index.js
@@ -15,6 +15,7 @@ export default function TcfSecondLayerUserDecision({
   hasConsent = true,
   hasLegitimateInterest = true,
   vendorList,
+  expandedContent,
   i18n
 }) {
   const [expanded, setExpanded] = useState(false)
@@ -22,76 +23,6 @@ export default function TcfSecondLayerUserDecision({
   const handleItemClick = () => {
     setExpanded(!expanded)
   }
-
-  const PolicyUrl = () => (
-    <>
-      <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.POLICY_URL}</h3>
-      <a
-        className={`${baseClass}-text ${baseClass}-text--expanded`}
-        href={info.policyUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {info.policyUrl}
-      </a>
-    </>
-  )
-  const Information = ({ids, vendorList}) =>
-    ids.map(id => (
-      <div key={`${id}-purposes`} className={`${baseClass}-paragraph`}>
-        <p className={`${baseClass}-text ${baseClass}-text--expanded`}>
-          <strong>{vendorList && `${vendorList[id]?.name}: `}</strong>
-        </p>
-        <p className={`${baseClass}-text ${baseClass}-text--expanded`}>
-          {vendorList && vendorList[id]?.description}
-        </p>
-      </div>
-    ))
-
-  const ExpandedContent = () => (
-    <>
-      {info.policyUrl && <PolicyUrl />}
-      {!!info.purposes?.length && vendorList.purposes && (
-        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.PURPOSES}</h3>
-      )}
-      {!!info.purposes?.length && vendorList.purposes && (
-        <Information ids={info.purposes} vendorList={vendorList.purposes} />
-      )}
-      {!!info.legIntPurposes.length && vendorList.purposes && (
-        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.LEGITIMATE_INTEREST_PURPOSES}</h3>
-      )}
-      {!!info.legIntPurposes?.length && vendorList.purposes && (
-        <Information
-          ids={info.legIntPurposes}
-          vendorList={vendorList.purposes}
-        />
-      )}
-      {!!info.specialPurposes?.length && vendorList.specialPurposes && (
-        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.SPECIAL_PURPOSES}</h3>
-      )}
-      {!!info.specialPurposes?.length && vendorList.specialPurposes && (
-        <Information
-          ids={info.specialPurposes}
-          vendorList={vendorList.specialPurposes}
-        />
-      )}
-      {!!info.features?.length && vendorList.features && (
-        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.FEATURES}</h3>
-      )}
-      {!!info.features?.length && vendorList.features && (
-        <Information ids={info.features} vendorList={vendorList.features} />
-      )}
-      {!!info.specialFeatures?.length && vendorList.specialFeatures && (
-        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.SPECIAL_FEATURES}</h3>
-      )}
-      {!!info.specialFeatures?.length && vendorList.specialFeatures && (
-        <Information
-          ids={info.specialFeatures}
-          vendorList={vendorList.specialFeatures}
-        />
-      )}
-    </>
-  )
 
   const Switchs = () => (
     <div className={`${baseClass}-switchs`}>
@@ -136,7 +67,7 @@ export default function TcfSecondLayerUserDecision({
       </div>
       {expanded && (
         <div className={`${baseClass}-container--expanded`}>
-          <ExpandedContent />
+          {expandedContent({info, baseClass})}
         </div>
       )}
     </>
@@ -153,7 +84,8 @@ TcfSecondLayerUserDecision.propTypes = {
   onConsentChange: PropTypes.func,
   onLegitimateInterestChange: PropTypes.func,
   vendorList: PropTypes.object,
-  i18n: PropTypes.object
+  i18n: PropTypes.object,
+  expandedContent: PropTypes.func.isRequired
 }
 
 TcfSecondLayerUserDecision.defaultProps = {

--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-vendor-expandedContent/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-vendor-expandedContent/index.js
@@ -1,0 +1,85 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function TcfSecondLayerVendorExpandedContent({
+  info,
+  i18n,
+  baseClass,
+  vendorList
+}) {
+  const PolicyUrl = () => (
+    <>
+      <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.POLICY_URL}</h3>
+      <a
+        className={`${baseClass}-text ${baseClass}-text--expanded`}
+        href={info.policyUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {info.policyUrl}
+      </a>
+    </>
+  )
+  const Information = ({ids, vendorList}) =>
+    ids.map(id => (
+      <div key={`${id}-purposes`} className={`${baseClass}-paragraph`}>
+        <p className={`${baseClass}-text ${baseClass}-text--expanded`}>
+          <strong>{vendorList && `${vendorList[id]?.name}: `}</strong>
+        </p>
+        <p className={`${baseClass}-text ${baseClass}-text--expanded`}>
+          {vendorList && vendorList[id]?.description}
+        </p>
+      </div>
+    ))
+  return (
+    <>
+      {info.policyUrl && <PolicyUrl />}
+      {!!info.purposes?.length && vendorList.purposes && (
+        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.PURPOSES}</h3>
+      )}
+      {!!info.purposes?.length && vendorList.purposes && (
+        <Information ids={info.purposes} vendorList={vendorList.purposes} />
+      )}
+      {!!info.legIntPurposes.length && vendorList.purposes && (
+        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.LEGITIMATE_INTEREST_PURPOSES}</h3>
+      )}
+      {!!info.legIntPurposes?.length && vendorList.purposes && (
+        <Information
+          ids={info.legIntPurposes}
+          vendorList={vendorList.purposes}
+        />
+      )}
+      {!!info.specialPurposes?.length && vendorList.specialPurposes && (
+        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.SPECIAL_PURPOSES}</h3>
+      )}
+      {!!info.specialPurposes?.length && vendorList.specialPurposes && (
+        <Information
+          ids={info.specialPurposes}
+          vendorList={vendorList.specialPurposes}
+        />
+      )}
+      {!!info.features?.length && vendorList.features && (
+        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.FEATURES}</h3>
+      )}
+      {!!info.features?.length && vendorList.features && (
+        <Information ids={info.features} vendorList={vendorList.features} />
+      )}
+      {!!info.specialFeatures?.length && vendorList.specialFeatures && (
+        <h3>{i18n.VENDOR_PAGE.GROUPS.EXPANDED.SPECIAL_FEATURES}</h3>
+      )}
+      {!!info.specialFeatures?.length && vendorList.specialFeatures && (
+        <Information
+          ids={info.specialFeatures}
+          vendorList={vendorList.specialFeatures}
+        />
+      )}
+    </>
+  )
+}
+
+TcfSecondLayerVendorExpandedContent.propTypes = {
+  info: PropTypes.object.isRequired,
+  baseClass: PropTypes.string.isRequired,
+  i18n: PropTypes.object.isRequired,
+  vendorList: PropTypes.object.isRequired
+}

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -9,7 +9,7 @@ import TcfSecondLayerDecisionGroup from './components/tcf-secondLayer-decision-g
 import TcfSecondLayerVendorExpandedContent from './components/tcf-secondLayer-vendor-expandedContent'
 
 import {I18N, ADEVINTA_COLLECTED_CONSENTS} from './settings'
-import TcfSecondLayerPurposeExpandedContent from './components/tcf-secondLayer-purpose-expandedContent'
+import TcfSecondLayerLegalExpandedContent from './components/tcf-secondLayer-legal-expandedContent'
 
 const CLASS = 'sui-TcfSecondLayer'
 const groupBaseClass = `${CLASS}-group`
@@ -162,11 +162,8 @@ export default function TcfSecondLayer({
     />
   )
 
-  const purposeExpandedContent = props => (
-    <TcfSecondLayerPurposeExpandedContent
-      {...props}
-      baseClass={groupBaseClass}
-    />
+  const legalExpandedContent = props => (
+    <TcfSecondLayerLegalExpandedContent {...props} baseClass={groupBaseClass} />
   )
   return (
     <div className={CLASS}>
@@ -221,7 +218,7 @@ export default function TcfSecondLayer({
               onAcceptAll={() => handleAcceptAll({group: 'purposes'})}
               onRejectAll={() => handleRejectAll({group: 'purposes'})}
               vendorList={vendorListState}
-              expandedContent={purposeExpandedContent}
+              expandedContent={legalExpandedContent}
             />
           )}
           {!!vendorListState?.specialFeatures && !!state?.specialFeatures && (
@@ -240,7 +237,7 @@ export default function TcfSecondLayer({
               onAcceptAll={handleAcceptAllSpecialFeatures}
               onRejectAll={handleRejectAllSpecialFeatures}
               vendorList={vendorListState}
-              expandedContent={purposeExpandedContent}
+              expandedContent={legalExpandedContent}
             />
           )}
           {!!vendorListState?.specialPurposes && (
@@ -252,7 +249,7 @@ export default function TcfSecondLayer({
               hasLegitimateInterest={false}
               i18n={i18n}
               vendorList={vendorListState}
-              expandedContent={purposeExpandedContent}
+              expandedContent={legalExpandedContent}
             />
           )}
           {!!vendorListState?.features && (
@@ -264,7 +261,7 @@ export default function TcfSecondLayer({
               hasLegitimateInterest={false}
               i18n={i18n}
               vendorList={vendorListState}
-              expandedContent={purposeExpandedContent}
+              expandedContent={legalExpandedContent}
             />
           )}
           {!!state?.vendors && !!vendorListState?.vendors && (

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -8,7 +8,7 @@ import IconClose from './components/iconClose'
 import TcfSecondLayerDecisionGroup from './components/tcf-secondLayer-decision-group'
 import TcfSecondLayerVendorExpandedContent from './components/tcf-secondLayer-vendor-expandedContent'
 
-import {I18N} from './settings'
+import {I18N, ADEVINTA_COLLECTED_CONSENTS} from './settings'
 import TcfSecondLayerPurposeExpandedContent from './components/tcf-secondLayer-purpose-expandedContent'
 
 const CLASS = 'sui-TcfSecondLayer'
@@ -55,7 +55,11 @@ export default function TcfSecondLayer({
           value: true
         })
       }
-      setState({vendors: userConsent.vendor, purposes: userConsent.purpose})
+      setState({
+        vendors: userConsent.vendor,
+        purposes: userConsent.purpose,
+        specialFeatures: userConsent.specialFeatures
+      })
     }
     getVendorListAndConsent()
   }, [getVendorList, loadUserConsent, lang])
@@ -104,22 +108,26 @@ export default function TcfSecondLayer({
     changeAllGroup({group, value: true})
   }
 
-  const handleVendorsConsentsChange = ({index, value}) => {
+  const handleConsentsChange = ({group, index, value}) => {
     setState(prevState => {
-      const {vendors} = prevState
-      const {consents} = vendors
+      const {consents} = prevState[group]
       consents[index] = !value
-      return {...prevState, vendors: {...prevState.vendors, consents}}
+      return {
+        ...prevState,
+        [group]: {...prevState[group], consents}
+      }
     })
   }
-  const handlePurposesConsentsChange = ({index, value}) => {
-    setState(prevState => {
-      const {purposes} = prevState
-      const {consents} = purposes
-      consents[index] = !value
-      return {...prevState, purposes: {...prevState.purposes, consents}}
-    })
-  }
+
+  // const handleFeaturesChange = ({group, index, value}) => {
+  //   setState(prevState => {
+  //     prevState[group][index] = !value
+  //     return {
+  //       ...prevState,
+  //       [group]: {...prevState[group]}
+  //     }
+  //   })
+  // }
 
   const Logo = () => (
     <img
@@ -189,10 +197,27 @@ export default function TcfSecondLayer({
               baseClass={groupBaseClass}
               descriptions={vendorListState.purposes}
               state={state.purposes}
-              onConsentChange={handlePurposesConsentsChange}
+              filteredIds={ADEVINTA_COLLECTED_CONSENTS.purposes}
+              onConsentChange={props =>
+                handleConsentsChange({group: 'purposes', ...props})
+              }
+              hasConsent
+              hasLegitimateInterest={false}
               i18n={i18n}
               onAcceptAll={() => handleAcceptAll({group: 'purposes'})}
               onRejectAll={() => handleRejectAll({group: 'purposes'})}
+              vendorList={vendorListState}
+              expandedContent={purposeExpandedContent}
+            />
+          )}
+          {!!vendorListState?.features && (
+            <TcfSecondLayerDecisionGroup
+              name={i18n.SECOND_LAYER.FEATURES_TITLE}
+              baseClass={groupBaseClass}
+              descriptions={vendorListState.features}
+              hasConsent={false}
+              hasLegitimateInterest={false}
+              i18n={i18n}
               vendorList={vendorListState}
               expandedContent={purposeExpandedContent}
             />
@@ -203,7 +228,11 @@ export default function TcfSecondLayer({
               baseClass={groupBaseClass}
               descriptions={vendorListState.vendors}
               state={state.vendors}
-              onConsentChange={handleVendorsConsentsChange}
+              onConsentChange={props =>
+                handleConsentsChange({group: 'vendors', ...props})
+              }
+              hasConsent
+              hasLegitimateInterest={false}
               i18n={i18n}
               onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
               onRejectAll={() => handleRejectAll({group: 'vendors'})}

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -58,7 +58,7 @@ export default function TcfSecondLayer({
       setState({
         vendors: userConsent.vendor,
         purposes: userConsent.purpose,
-        specialFeatures: userConsent.specialFeatures
+        specialFeatures: userConsent.specialFeatureOptins
       })
     }
     getVendorListAndConsent()
@@ -108,6 +108,19 @@ export default function TcfSecondLayer({
     changeAllGroup({group, value: true})
   }
 
+  const handleAcceptAllSpecialFeatures = () => {
+    setState({
+      ...state,
+      specialFeatures: ADEVINTA_COLLECTED_CONSENTS.specialFeatures
+    })
+  }
+  const handleRejectAllSpecialFeatures = () => {
+    setState({
+      ...state,
+      specialFeatures: []
+    })
+  }
+
   const handleConsentsChange = ({group, index, value}) => {
     setState(prevState => {
       const {consents} = prevState[group]
@@ -119,15 +132,20 @@ export default function TcfSecondLayer({
     })
   }
 
-  // const handleFeaturesChange = ({group, index, value}) => {
-  //   setState(prevState => {
-  //     prevState[group][index] = !value
-  //     return {
-  //       ...prevState,
-  //       [group]: {...prevState[group]}
-  //     }
-  //   })
-  // }
+  const handleSpecialFeaturesChange = ({index}) => {
+    setState(prevState => {
+      let {specialFeatures} = prevState
+      if (specialFeatures.includes(index)) {
+        specialFeatures = specialFeatures.filter(value => index !== value)
+      } else {
+        specialFeatures.push(index)
+      }
+      return {
+        ...prevState,
+        specialFeatures
+      }
+    })
+  }
 
   const Logo = () => (
     <img
@@ -154,6 +172,7 @@ export default function TcfSecondLayer({
       baseClass={groupBaseClass}
     />
   )
+
   return (
     <div className={CLASS}>
       <SuiModal
@@ -206,6 +225,23 @@ export default function TcfSecondLayer({
               i18n={i18n}
               onAcceptAll={() => handleAcceptAll({group: 'purposes'})}
               onRejectAll={() => handleRejectAll({group: 'purposes'})}
+              vendorList={vendorListState}
+              expandedContent={purposeExpandedContent}
+            />
+          )}
+          {!!vendorListState?.specialFeatures && !!state?.specialFeatures && (
+            <TcfSecondLayerDecisionGroup
+              name={i18n.SECOND_LAYER.SPECIAL_FEATURES_TITLE}
+              baseClass={groupBaseClass}
+              descriptions={vendorListState.specialFeatures}
+              state={state.specialFeatures}
+              filteredIds={ADEVINTA_COLLECTED_CONSENTS.specialFeatures}
+              onConsentChange={handleSpecialFeaturesChange}
+              hasConsent
+              hasLegitimateInterest={false}
+              i18n={i18n}
+              onAcceptAll={handleAcceptAllSpecialFeatures}
+              onRejectAll={handleRejectAllSpecialFeatures}
               vendorList={vendorListState}
               expandedContent={purposeExpandedContent}
             />

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -58,7 +58,7 @@ export default function TcfSecondLayer({
       setState({
         vendors: userConsent.vendor,
         purposes: userConsent.purpose,
-        specialFeatures: userConsent.specialFeatureOptins
+        specialFeatures: userConsent.specialFeatures
       })
     }
     getVendorListAndConsent()
@@ -109,40 +109,36 @@ export default function TcfSecondLayer({
   }
 
   const handleAcceptAllSpecialFeatures = () => {
+    const specialFeatures = {}
+    ADEVINTA_COLLECTED_CONSENTS.specialFeatures.forEach(
+      value => (specialFeatures[value] = true)
+    )
     setState({
       ...state,
-      specialFeatures: ADEVINTA_COLLECTED_CONSENTS.specialFeatures
+      specialFeatures
     })
   }
   const handleRejectAllSpecialFeatures = () => {
     setState({
       ...state,
-      specialFeatures: []
+      specialFeatures: {}
     })
   }
 
   const handleConsentsChange = ({group, index, value}) => {
     setState(prevState => {
       const {consents} = prevState[group]
-      consents[index] = !value
-      return {
-        ...prevState,
-        [group]: {...prevState[group], consents}
-      }
-    })
-  }
-
-  const handleSpecialFeaturesChange = ({index}) => {
-    setState(prevState => {
-      let {specialFeatures} = prevState
-      if (specialFeatures.includes(index)) {
-        specialFeatures = specialFeatures.filter(value => index !== value)
+      if (consents) {
+        consents[index] = !value
+        return {
+          ...prevState,
+          [group]: {...prevState[group], consents}
+        }
       } else {
-        specialFeatures.push(index)
-      }
-      return {
-        ...prevState,
-        specialFeatures
+        return {
+          ...prevState,
+          [group]: {...prevState[group], [index]: !value}
+        }
       }
     })
   }
@@ -172,7 +168,6 @@ export default function TcfSecondLayer({
       baseClass={groupBaseClass}
     />
   )
-
   return (
     <div className={CLASS}>
       <SuiModal
@@ -236,7 +231,9 @@ export default function TcfSecondLayer({
               descriptions={vendorListState.specialFeatures}
               state={state.specialFeatures}
               filteredIds={ADEVINTA_COLLECTED_CONSENTS.specialFeatures}
-              onConsentChange={handleSpecialFeaturesChange}
+              onConsentChange={props =>
+                handleConsentsChange({group: 'specialFeatures', ...props})
+              }
               hasConsent
               hasLegitimateInterest={false}
               i18n={i18n}

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -210,6 +210,18 @@ export default function TcfSecondLayer({
               expandedContent={purposeExpandedContent}
             />
           )}
+          {!!vendorListState?.specialPurposes && (
+            <TcfSecondLayerDecisionGroup
+              name={i18n.SECOND_LAYER.SPECIAL_PURPOSES_TITLE}
+              baseClass={groupBaseClass}
+              descriptions={vendorListState.specialPurposes}
+              hasConsent={false}
+              hasLegitimateInterest={false}
+              i18n={i18n}
+              vendorList={vendorListState}
+              expandedContent={purposeExpandedContent}
+            />
+          )}
           {!!vendorListState?.features && (
             <TcfSecondLayerDecisionGroup
               name={i18n.SECOND_LAYER.FEATURES_TITLE}

--- a/components/tcf/secondLayer/src/settings.js
+++ b/components/tcf/secondLayer/src/settings.js
@@ -1,3 +1,10 @@
+export const ADEVINTA_COLLECTED_CONSENTS = {
+  purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  specialPurposes: [1, 2],
+  features: [3],
+  specialFeatures: [1]
+}
+
 const DEFAULT_I18N = {
   LEGITIMATE_INTEREST_COPY: 'Interés legítimo',
   CONSENT_COPY: '',
@@ -6,7 +13,10 @@ const DEFAULT_I18N = {
   DISABLE_BUTTON: 'Deshabilitar todo',
   ENABLE_BUTTON: 'Habilitar todo',
   SECOND_LAYER: {
-    PURPOSES_TITLE: 'Autorizo'
+    PURPOSES_TITLE: 'Autorizo',
+    SPECIAL_PURPOSES_TITLE: 'Propósitos especiales',
+    FEATURES_TITLE: 'Características',
+    SPECIAL_FEATURES_TITLE: 'Características especiales'
   },
   VENDOR_PAGE: {
     TITLE: 'Cookies propios o de terceros para publicidad segmentada',

--- a/components/tcf/secondLayer/src/settings.js
+++ b/components/tcf/secondLayer/src/settings.js
@@ -1,10 +1,13 @@
 const DEFAULT_I18N = {
   LEGITIMATE_INTEREST_COPY: 'Interés legítimo',
-  CONSENT_COPY: 'Consentimiento',
+  CONSENT_COPY: '',
   GO_BACK_BUTTON: 'Volver atrás',
   ACCEPT_BUTTON: 'Aceptar',
   DISABLE_BUTTON: 'Deshabilitar todo',
   ENABLE_BUTTON: 'Habilitar todo',
+  SECOND_LAYER: {
+    PURPOSES_TITLE: 'Autorizo'
+  },
   VENDOR_PAGE: {
     TITLE: 'Cookies propios o de terceros para publicidad segmentada',
     TEXT:

--- a/demo/tcf/utils/borosMock.js
+++ b/demo/tcf/utils/borosMock.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 const mockedEmptyUserConsent = {
   isNew: true,
-  specialFeatureOptins: [],
+  specialFeature: {},
   purpose: {
     consents: {},
     legitimateInterests: {}
@@ -13,7 +13,7 @@ const mockedEmptyUserConsent = {
 }
 const mockedFullUserConsent = {
   isNew: false,
-  specialFeatureOptins: [],
+  specialFeature: {1: true},
   purpose: {
     consents: {
       1: false,

--- a/demo/tcf/utils/borosMock.js
+++ b/demo/tcf/utils/borosMock.js
@@ -141,6 +141,70 @@ const mockedVendorList = {
         'To develop new products and improve products vendors can:\n* Use information to improve their existing products with new features and to develop new products\n* Create new models and algorithms through machine learning\nVendors cannot:\n* Conduct any other data processing operation allowed under a different purpose under this purpose'
     }
   },
+  features: {
+    '1': {
+      id: 1,
+      name: 'Cotejar y combinar fuentes de datos off line',
+      description:
+        'Los datos obtenidos de fuentes de datos off line pueden combinarse con su actividad on line para respaldar una o más finalidades.',
+      descriptionLegal:
+        'Los proveedores pueden: \n* Combinar los datos obtenidos off line con los datos recogidos on line en apoyo de una o más Finalidades o Finalidades especiales.'
+    },
+    '2': {
+      id: 2,
+      name: 'Vincular diferentes dispositivos',
+      description:
+        'Se puede determinar que diferentes dispositivos pertenecen a usted o a su hogar para una o más finalidades.',
+      descriptionLegal:
+        'Los proveedores pueden:\n* Determinar de forma determinista que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Determinar de forma probabilística que dos o más dispositivos pertenecen al mismo usuario u hogar\n* Analizar activamente las características del dispositivo para encontrar su identificación probabilística si los usuarios han permitido a los proveedores analizar activamente las características del dispositivo para su identificación (Funcionalidad especial 2)\n'
+    },
+    '3': {
+      id: 3,
+      name:
+        'Recibir y utilizar para su identificación las características del dispositivo que    se envían automáticamente',
+      description:
+        'Su dispositivo puede distinguirse de otros dispositivos a partir de la información que envía automáticamente, como la dirección IP o el tipo de navegador.',
+      descriptionLegal:
+        'Los proveedores pueden:\n* Crear un identificador utilizando los datos recopilados automáticamente en un dispositivo para características específicas, por ejemplo, dirección IP o la cadena de agente de usuario.\n* Utilizar este identificador para intentar volver a identificar un dispositivo.\nLos proveedores no pueden:\n* Crear un identificador utilizando datos recogidos mediante el análisis activo de un dispositivo para hallar funcionalidads específicas, por ejemplo, fuentes instaladas o resolución de pantalla sin aceptación independiente del usuario para analizar de forma activa las características del dispositivo para su identificación.\n* Utilizar este identificador para volver a identificar un dispositivo.\n'
+    }
+  },
+  specialFeatures: {
+    1: {
+      id: 1,
+      name: 'Utilizar datos de localización geográfica precisa',
+      description:
+        'Sus datos de localización geográfica precisa se pu…ación puede tener una precisión de varios metros.',
+      descriptionLegal:
+        'Los proveedores pueden:↵* Recoger y tratar datos d…esto puede tener una precisión de varios metros.↵'
+    },
+    2: {
+      id: 2,
+      name:
+        'Analizar activamente las características del dispositivo para su identificación',
+      description:
+        'Su dispositivo puede identificarse basándose en un…n única de las características de su dispositivo.',
+      descriptionLegal:
+        'Los proveedores pueden:↵* Crear un identificador u…icador para volver a identificar un dispositivo.↵'
+    }
+  },
+  specialPurposes: {
+    '1': {
+      id: 1,
+      name: 'Garantizar la seguridad, evitar fraudes y depurar errores',
+      description:
+        'Sus datos pueden utilizarse para supervisar y evitar actividades fraudulentas, y para asegurar que los sistemas y procesos funcionen de forma correcta y segura.',
+      descriptionLegal:
+        'Para garantizar la seguridad, evitar fraudes y depurar errores, los proveedores pueden:\n* Asegurarse de que los datos se transmitan de forma segura \n* Detectar y evitar actividades maliciosas, fraudulentas, inaceptables o ilegales.\n* Asegurar el funcionamiento correcto y eficaz de los sistemas y procesos, lo que incluye supervisar y mejorar el rendimiento de los sistemas y procesos empleados en las finalidades permitidas\nLos proveedores no pueden:\n* Llevar a cabo ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\nNota: Los datos recopilados y utilizados para garantizar la seguridad, evitar el fraude y depurar errores pueden incluir características del dispositivo enviadas automáticamente para su identificación, datos de geolocalización precisos y datos obtenidos analizando de forma activa las características del dispositivo para su identificación sin que sea necesario revelar más información y/o una aceptación independiente.  \n'
+    },
+    '2': {
+      id: 2,
+      name: 'Servir técnicamente anuncios o contenido',
+      description:
+        'Su dispositivo puede recibir y enviar información que le permita ver e interactuar con anuncios y contenido.',
+      descriptionLegal:
+        'Para servir información y responder a solicitudes técnicas, los proveedores pueden:\n* Utilizar la dirección IP de un usuario para entregar un anuncio a través de Internet\n* Responder a la interacción de un usuario con un anuncio enviando al usuario a una página de destino\n* Utilizar la dirección IP de un usuario para entregar contenido a través de Internet\n* Responder a la interacción de un usuario con el contenido enviando al usuario a una página de destino\n* Utilizar información sobre el tipo de dispositivo y sus capacidades para entregar anuncios o contenido, por ejemplo, para entregar el archivo publicitario o de vídeo de tamaño adecuado en un formato compatible con el dispositivo\nLos proveedores no pueden:\n* Llevar a cabo, según esta finalidad, ninguna otra operación de tratamiento de datos permitida en virtud de una finalidad distinta.\n'
+    }
+  },
   vendors: {
     '8': {
       id: 8,
@@ -221,24 +285,6 @@ const mockedVendorList = {
       features: [1, 2, 3],
       specialFeatures: [],
       policyUrl: 'https://www.conversantmedia.eu/legal/privacy-policy'
-    }
-  },
-  specialFeatures: {
-    '1': {
-      id: 1,
-      name: 'Use precise geolocation data',
-      description:
-        'Your precise geolocation data can be used in support of one or more purposes. This means your location can be accurate to within several meters.',
-      descriptionLegal:
-        'Vendors can:\n* Collect and process precise geolocation data in support of one or more purposes.\nN.B. Precise geolocation means that there are no restrictions on the precision of a user’s location; this can be accurate to within several meters.'
-    },
-    '2': {
-      id: 2,
-      name: 'Actively scan device characteristics for identification',
-      description:
-        "Your device can be identified based on a scan of your device's unique combination of characteristics.",
-      descriptionLegal:
-        'Vendors can:\n* Create an identifier using data collected via actively scanning a device for specific characteristics, e.g. installed fonts or screen resolution.\n* Use such an identifier to re-identify a device.'
     }
   }
 }


### PR DESCRIPTION
## Description
This is a first approach to second layer. It's functional but doesn't have the styles properly setted and needs to be completed with the behaviour for legitimateIntereses ~= consent


## Solves ticket/s
https://jira.scmspain.com/browse/PSP-3287

## Expected behavior
Show purposes, specialPurposes,  features, and specialFeatures. Vendors are shown too but maybe need to be moved to another page.

## Review steps
Use the demo or the demo of tcf/ui linking tcf/secondLayer

<img width="615" alt="Screenshot 2020-07-08 at 16 25 11" src="https://user-images.githubusercontent.com/45286922/86930722-9bd4d480-c137-11ea-8062-5a1fcec57882.png">

## Further considerations
Any NB features could be addressed in [3rd iteration](https://jira.scmspain.com/browse/PSP-3308)

TODO:
- Remove? the vendors from this layer to a new link
- Add logic to use legitimateInterest and Consent in a proper way
- Styles (pending some UX designs)
- Style LegalExpandedContent as MarkDown or similar
- Extract from hardcoding the  ADEVINTA_COLLECTED_CONSENTS to be injected by configuration 

## Memetized description
![layers](https://media.giphy.com/media/j5QFLjGfXKvCs7jmHC/giphy.gif