### PR TITLE
Feature/second layer remove legitimate interest

### DIFF
--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-decision-group/index.js
@@ -12,9 +12,7 @@ export default function TcfSecondLayerDecisionGroup({
   state,
   filteredIds,
   hasConsent,
-  hasLegitimateInterest,
   onConsentChange,
-  onLegitimateInterestChange,
   onAcceptAll,
   onRejectAll,
   vendorList,
@@ -33,7 +31,7 @@ export default function TcfSecondLayerDecisionGroup({
     <>
       <div className={`${baseClass}-title-container`}>
         <h2 className={`${baseClass}-title`}>{name}</h2>
-        {hasConsent || hasLegitimateInterest ? (
+        {hasConsent ? (
           <div className={`${baseClass}-buttons`}>
             <SuiButton size="small" design="outline" onClick={onRejectAll}>
               {i18n.DISABLE_BUTTON}
@@ -54,15 +52,10 @@ export default function TcfSecondLayerDecisionGroup({
             baseClass={`${baseClass}-item`}
             info={descriptions[key]}
             consentValue={consentValue}
-            legitimateInterestValue={state?.legitimateInterestValue?.[key]}
             hasConsent={hasConsent}
-            hasLegitimateInterest={hasLegitimateInterest}
             i18n={i18n}
             vendorList={vendorList}
             onConsentChange={value => onConsentChange({index: key, value})}
-            onLegitimateInterestChange={value =>
-              onLegitimateInterestChange({index: key, value})
-            }
             expandedContent={expandedContent}
           />
         )
@@ -79,9 +72,7 @@ TcfSecondLayerDecisionGroup.propTypes = {
   state: PropTypes.object,
   filteredIds: PropTypes.arrayOf(PropTypes.number),
   hasConsent: PropTypes.bool,
-  hasLegitimateInterest: PropTypes.bool,
   onConsentChange: PropTypes.func,
-  onLegitimateInterestChange: PropTypes.func,
   onAcceptAll: PropTypes.func,
   onRejectAll: PropTypes.func,
   vendorList: PropTypes.object,

--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-user-decision/index.js
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-user-decision/index.js
@@ -7,13 +7,10 @@ import IconAccordion from '../iconAccordion'
 
 export default function TcfSecondLayerUserDecision({
   onConsentChange,
-  onLegitimateInterestChange,
   baseClass,
   info,
   consentValue,
-  legitimateInterestValue,
   hasConsent = true,
-  hasLegitimateInterest = true,
   vendorList,
   expandedContent,
   i18n
@@ -35,15 +32,6 @@ export default function TcfSecondLayerUserDecision({
           onToggle={() => onConsentChange(consentValue)}
         />
       )}
-      {hasLegitimateInterest && (
-        <SuiSwitch
-          type="single"
-          name="groupItem"
-          value={legitimateInterestValue}
-          label={i18n.LEGITIMATE_INTEREST_COPY}
-          onToggle={() => onLegitimateInterestChange(legitimateInterestValue)}
-        />
-      )}
     </div>
   )
 
@@ -63,7 +51,7 @@ export default function TcfSecondLayerUserDecision({
           />
           <p className={`${baseClass}-text`}>{info.name}</p>
         </div>
-        {hasConsent || hasLegitimateInterest ? <Switchs /> : null}
+        {hasConsent ? <Switchs /> : null}
       </div>
       {expanded && (
         <div className={`${baseClass}-container--expanded`}>
@@ -77,18 +65,14 @@ export default function TcfSecondLayerUserDecision({
 TcfSecondLayerUserDecision.propTypes = {
   baseClass: PropTypes.string,
   hasConsent: PropTypes.bool,
-  hasLegitimateInterest: PropTypes.bool,
   info: PropTypes.object,
   consentValue: PropTypes.bool,
-  legitimateInterestValue: PropTypes.bool,
   onConsentChange: PropTypes.func,
-  onLegitimateInterestChange: PropTypes.func,
   vendorList: PropTypes.object,
   i18n: PropTypes.object,
   expandedContent: PropTypes.func.isRequired
 }
 
 TcfSecondLayerUserDecision.defaultProps = {
-  hasConsent: true,
-  hasLegitimateInterest: true
+  hasConsent: true
 }

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -96,7 +96,6 @@ export default function TcfSecondLayer({
     setState(prevState => {
       for (const key in vendorListState[group]) {
         prevState[group].consents[key] = value
-        prevState[group].legitimateInterests[key] = value
       }
       return {...prevState, [group]: prevState[group]}
     })
@@ -213,7 +212,6 @@ export default function TcfSecondLayer({
                 handleConsentsChange({group: 'purposes', ...props})
               }
               hasConsent
-              hasLegitimateInterest={false}
               i18n={i18n}
               onAcceptAll={() => handleAcceptAll({group: 'purposes'})}
               onRejectAll={() => handleRejectAll({group: 'purposes'})}
@@ -232,7 +230,6 @@ export default function TcfSecondLayer({
                 handleConsentsChange({group: 'specialFeatures', ...props})
               }
               hasConsent
-              hasLegitimateInterest={false}
               i18n={i18n}
               onAcceptAll={handleAcceptAllSpecialFeatures}
               onRejectAll={handleRejectAllSpecialFeatures}
@@ -246,7 +243,6 @@ export default function TcfSecondLayer({
               baseClass={groupBaseClass}
               descriptions={vendorListState.specialPurposes}
               hasConsent={false}
-              hasLegitimateInterest={false}
               i18n={i18n}
               vendorList={vendorListState}
               expandedContent={legalExpandedContent}
@@ -258,7 +254,6 @@ export default function TcfSecondLayer({
               baseClass={groupBaseClass}
               descriptions={vendorListState.features}
               hasConsent={false}
-              hasLegitimateInterest={false}
               i18n={i18n}
               vendorList={vendorListState}
               expandedContent={legalExpandedContent}
@@ -274,7 +269,6 @@ export default function TcfSecondLayer({
                 handleConsentsChange({group: 'vendors', ...props})
               }
               hasConsent
-              hasLegitimateInterest={false}
               i18n={i18n}
               onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
               onRejectAll={() => handleRejectAll({group: 'vendors'})}

--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -48,7 +48,7 @@ export default function TCFContainer({
   const handleSaveUserConsent = ({purpose, vendor, specialFeatures}) => {
     uiVisible({visible: false})
     saveUserConsent({purpose, vendor, specialFeatures})
-    onCloseModal()
+    onCloseModal && onCloseModal()
     setShowLayer(0)
   }
 

--- a/demo/tcf/secondLayer/demo/index.js
+++ b/demo/tcf/secondLayer/demo/index.js
@@ -13,9 +13,6 @@ const TcfSecondLayerDemo = () => {
     console.log('purposes', purpose)
     console.log('vendors', vendor)
   }
-  const uiVisible = ({visible}) => {
-    console.log('uiVisible called with visible to', visible)
-  }
   const handleGoBack = () => {
     console.log('go back button pressed')
   }
@@ -31,24 +28,20 @@ const TcfSecondLayerDemo = () => {
       </button>
       {isMobile && (
         <TcfSecondLayer
-          isOpen
           logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
           loadUserConsent={loadUserConsent}
           saveUserConsent={saveUserConsent}
           getVendorList={getVendorList}
-          uiVisible={uiVisible}
           onGoBack={handleGoBack}
           isMobile
         />
       )}
       {!isMobile && (
         <TcfSecondLayer
-          isOpen
           logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
           loadUserConsent={loadUserConsent}
           saveUserConsent={saveUserConsent}
           getVendorList={getVendorList}
-          uiVisible={uiVisible}
           onGoBack={handleGoBack}
         />
       )}

--- a/demo/tcf/utils/borosMock.js
+++ b/demo/tcf/utils/borosMock.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 const mockedEmptyUserConsent = {
   isNew: true,
-  specialFeature: {},
+  specialFeatures: {},
   purpose: {
     consents: {},
     legitimateInterests: {}
@@ -13,7 +13,7 @@ const mockedEmptyUserConsent = {
 }
 const mockedFullUserConsent = {
   isNew: false,
-  specialFeature: {1: true},
+  specialFeatures: {1: true},
   purpose: {
     consents: {
       1: false,


### PR DESCRIPTION
## Description
This PR removes the legitimateInterest toogle logic.
Also prevents a minor error if no onCloseModal function is provided to tcf/ui and update the demo for tcf/ui

## Jiras related
https://jira.scmspain.com/browse/PSP-3308

## Expected behavior
No visual or behavioural changes with this change. Only removes the possibility of enable the legitimate interest toggle

## Review steps
Demo of tcf/ui and tcf/secondLayer are functional

## Memetized description
![do less](https://media.giphy.com/media/2wZpm9zyceDyXHPf5S/giphy.gif)