### PR TITLE
fix(tcf/secondLayer): save purpose and specialFeatures data

### DIFF
--- a/components/tcf/firstLayer/src/index.js
+++ b/components/tcf/firstLayer/src/index.js
@@ -85,6 +85,7 @@ export default function TcfFirstLayer({
     ADEVINTA_COLLECTED_CONSENTS.purposes.forEach(index => {
       if (VLPurposes[index]) {
         purpose.consents[index] = true
+        purpose.legitimateInterests[index] = true
       }
     })
     ADEVINTA_COLLECTED_CONSENTS.specialFeatures.forEach(index => {
@@ -94,6 +95,7 @@ export default function TcfFirstLayer({
     })
     for (const key in VLVendors) {
       vendor.consents[key] = true
+      vendor.legitimateInterests[key] = true
     }
     handleCloseModal()
     saveUserConsent({purpose, vendor, specialFeatures})

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -57,14 +57,12 @@ export default function TcfSecondLayer({
         userConsent.vendor.legitimateInterests = {
           ...userConsent.vendor.consents
         }
-        userConsent.purpose.consents = format({
-          reference: purposes,
-          object: {},
-          value: true
+        userConsent.purpose.consents = {}
+        userConsent.purpose.legitimateInterests = {}
+        ADEVINTA_COLLECTED_CONSENTS.purposes.forEach(key => {
+          userConsent.purpose.consents[key] = true
+          userConsent.purpose.legitimateInterests[key] = true
         })
-        userConsent.purpose.legitimateInterests = {
-          ...userConsent.purpose.consents
-        }
         userConsent.specialFeatures = {}
         ADEVINTA_COLLECTED_CONSENTS.specialFeatures.forEach(
           key => (userConsent.specialFeatures[key] = true)
@@ -104,8 +102,8 @@ export default function TcfSecondLayer({
       object: vendor.legitimateInterests || {}
     })
     purpose.consents = format({
-      reference: vendorListState.vendors || {},
-      object: vendor.consents || {}
+      reference: vendorListState.purposes || {},
+      object: purpose.consents || {}
     })
     purpose.legitimateInterests = format({
       reference: vendorListState.purposes || {},
@@ -168,15 +166,17 @@ export default function TcfSecondLayer({
       if (consents && legitimateInterests) {
         consents[index] = !value
         legitimateInterests[index] = !value
-        return {
+        const nextState = {
           ...prevState,
           [group]: {...prevState[group], consents, legitimateInterests}
         }
+        return nextState
       } else {
-        return {
+        const nextState = {
           ...prevState,
           [group]: {...prevState[group], [index]: !value}
         }
+        return nextState
       }
     })
   }

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -54,6 +54,21 @@ export default function TcfSecondLayer({
           object: {},
           value: true
         })
+        userConsent.vendor.legitimateInterests = {
+          ...userConsent.vendor.consents
+        }
+        userConsent.purpose.consents = format({
+          reference: purposes,
+          object: {},
+          value: true
+        })
+        userConsent.purpose.legitimateInterests = {
+          ...userConsent.purpose.consents
+        }
+        userConsent.specialFeatures = {}
+        ADEVINTA_COLLECTED_CONSENTS.specialFeatures.forEach(
+          key => (userConsent.specialFeatures[key] = true)
+        )
       }
       setState({
         vendors: userConsent.vendor,
@@ -75,18 +90,40 @@ export default function TcfSecondLayer({
     })
     return object
   }
-  const formatConsentObject = ({vendor = {}}) => {
+  const formatConsentObject = ({
+    vendor = {},
+    purpose = {},
+    specialFeatures = {}
+  }) => {
     vendor.consents = format({
       reference: vendorListState.vendors || {},
       object: vendor.consents || {}
     })
-    return {vendor}
+    vendor.legitimateInterests = format({
+      reference: vendorListState.vendors || {},
+      object: vendor.legitimateInterests || {}
+    })
+    purpose.consents = format({
+      reference: vendorListState.vendors || {},
+      object: vendor.consents || {}
+    })
+    purpose.legitimateInterests = format({
+      reference: vendorListState.purposes || {},
+      object: purpose.legitimateInterests || {}
+    })
+    const consentSpecialFeatures = format({
+      reference: vendorListState.specialFeatures || {},
+      object: specialFeatures
+    })
+    return {vendor, purpose, specialFeatures: consentSpecialFeatures}
   }
 
   const handleSaveExitClick = () => {
     saveUserConsent(
       formatConsentObject({
-        vendor: state.vendors
+        vendor: state.vendors,
+        purpose: state.purposes,
+        specialFeatures: state.specialFeatures
       })
     )
     setModalOpen(false)
@@ -96,6 +133,7 @@ export default function TcfSecondLayer({
     setState(prevState => {
       for (const key in vendorListState[group]) {
         prevState[group].consents[key] = value
+        prevState[group].legitimateInterests[key] = value
       }
       return {...prevState, [group]: prevState[group]}
     })
@@ -126,12 +164,13 @@ export default function TcfSecondLayer({
 
   const handleConsentsChange = ({group, index, value}) => {
     setState(prevState => {
-      const {consents} = prevState[group]
-      if (consents) {
+      const {consents, legitimateInterests} = prevState[group]
+      if (consents && legitimateInterests) {
         consents[index] = !value
+        legitimateInterests[index] = !value
         return {
           ...prevState,
-          [group]: {...prevState[group], consents}
+          [group]: {...prevState[group], consents, legitimateInterests}
         }
       } else {
         return {


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

![image](https://user-images.githubusercontent.com/20399660/87055178-4adee200-c204-11ea-8f4c-5be1a6b73c68.png)

With current version, no `purpose` data is being saved, neither `specialFeatures` nor `legitimateInterests`.
This fix adds the data initialization and manipulation from the second layer.


## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3347

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

Data is populated and saved to the consent string

![image](https://user-images.githubusercontent.com/20399660/87055365-84afe880-c204-11ea-9b22-9aaa7876f067.png)

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

Can be tested in the demo, check the saved value with `window.__tcfapi('getTCData', 2, console.log)`

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/Rkis28kMJd1aE/giphy.gif)