### PR TITLE
Fix/save consent on close modal

### DIFF
--- a/components/tcf/firstLayer/src/index.js
+++ b/components/tcf/firstLayer/src/index.js
@@ -133,7 +133,7 @@ export default function TcfFirstLayer({
           closeOnEscKeyDown
           header={<img className={`${CLASS}-logo`} src={logo} alt="logo" />}
           iconClose={<IconClose class={`${CLASS}-icon-close`} />}
-          onClose={handleCloseModal}
+          onClose={handleSaveExitClick}
           fitContent
         >
           <Content />

--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -124,7 +124,7 @@ export default function TcfSecondLayer({
         specialFeatures: state.specialFeatures
       })
     )
-    setModalOpen(false)
+    handleCloseModal()
   }
 
   const changeAllGroup = ({group, value}) => {
@@ -211,7 +211,7 @@ export default function TcfSecondLayer({
         closeOnEscKeyDown
         header={isMobile ? <Logo /> : false}
         iconClose={isMobile ? <IconClose /> : false}
-        onClose={handleCloseModal}
+        onClose={handleSaveExitClick}
         fitContent
       >
         {!isMobile && <Logo />}


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Current definition is to save the current consent object if the user closes the modal.
This PR fixes this to apply the save consent on that situation, in the first and second layers.

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3333

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* When the user closes the modal, it saves the current consent state.

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

* visually tested in local
`HOST=local.schibsted.io npm run dev tcf/ui -- --link-package=components/tcf/secondLayer --link-package=components/tcf/firstLayer`

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

* A more user-friendly behavior would be to return to the first layer if the modal is closed in the second layer (as others CMP implementors do), but actually these are the given requirements

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/iMJSAcBKPuc8dhQbQ2/giphy.gif)