### PR TITLE
fix(tcf/firstLayer): remove scroll listener on unmount

### DIFF
--- a/components/tcf/firstLayer/src/index.js
+++ b/components/tcf/firstLayer/src/index.js
@@ -66,6 +66,7 @@ export default function TcfFirstLayer({
   useEffect(() => {
     initialYOffset = window.pageYOffset
     document.addEventListener('scroll', checkScroll, {passive: true})
+    return () => document.removeEventListener('scroll', checkScroll)
   }, [])
 
   const handleSettingsClick = () => {
@@ -100,7 +101,6 @@ export default function TcfFirstLayer({
   }
 
   const handleCloseModal = () => {
-    document.removeEventListener('scroll', checkScroll)
     setShow(false)
   }
 


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

When we go from the first layer to any other layer, the scroll listener should not be registered.
> the scroll listener is intended to be used for users that keep scrolling down with the first layer opened so it'll apply a default consent, but if the user has interacted with the first layer opening the configuration, it has not sense to keep listening the scroll (and closing the modal if the user is scrolling out the modal)

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3355

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* when the first layer is mounted, the scroll listener is registered, and when is unmounted, the scroll listener is unregistered

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

tested in the local demo 
`HOST=local.schibsted.io npm run dev tcf/ui -- --link-package=components/tcf/firstLayer`


## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/8CAFRDokyQkhi/giphy.gif)