### PR TITLE
Feature/tcf layers flow

### DIFF
--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -11,7 +11,6 @@ export default function TCFContainer({
   saveUserConsent,
   uiVisible,
   isMobile,
-  isTablet,
   lang,
   logo,
   showVendors,
@@ -22,7 +21,7 @@ export default function TCFContainer({
   useEffect(() => {
     if (showVendors) {
       uiVisible({visible: true})
-      setShowLayer(3)
+      setShowLayer(2)
     }
   }, [showVendors, uiVisible])
 
@@ -44,7 +43,15 @@ export default function TCFContainer({
     setShowLayer(3)
   }
   const handleSecondLayerGoBack = () => {
-    setShowLayer(1)
+    if (showVendors) {
+      onCloseModal && onCloseModal()
+      setShowLayer(0)
+    } else {
+      setShowLayer(1)
+    }
+  }
+  const handleThirdLayerGoBack = () => {
+    setShowLayer(2)
   }
   const handleOpenCookiepolicyLayer = () => {
     setShowLayer(3)
@@ -62,7 +69,6 @@ export default function TCFContainer({
         <Suspense fallback={<div />}>
           <FirstLayer
             isMobile={isMobile}
-            isTablet={isTablet}
             lang={lang}
             logo={logo}
             getVendorList={getVendorList}
@@ -98,7 +104,7 @@ export default function TCFContainer({
             loadUserConsent={loadUserConsent}
             saveUserConsent={handleSaveUserConsent}
             getVendorList={getVendorList}
-            onGoBack={handleSecondLayerGoBack}
+            onGoBack={handleThirdLayerGoBack}
           />
         </Suspense>
       )}
@@ -115,7 +121,6 @@ TCFContainer.propTypes = {
   onCloseModal: PropTypes.func,
   saveUserConsent: PropTypes.func,
   isMobile: PropTypes.bool,
-  isTablet: PropTypes.bool,
   showVendors: PropTypes.bool,
   lang: PropTypes.string,
   logo: PropTypes.string,

--- a/components/tcf/ui/src/index.js
+++ b/components/tcf/ui/src/index.js
@@ -8,7 +8,6 @@ export default function TcfUi({
   lang,
   logo,
   isMobile,
-  isTablet,
   showVendors,
   onCloseModal,
   showInModalForMobile = false
@@ -20,7 +19,6 @@ export default function TcfUi({
           lang={lang}
           logo={logo}
           isMobile={isMobile}
-          isTablet={isTablet}
           getVendorList={({language}) => service.getVendorList({language})}
           loadUserConsent={() => service.loadUserConsent()}
           saveUserConsent={({purpose, vendor, specialFeatures}) =>
@@ -40,7 +38,6 @@ TcfUi.displayName = 'TcfUi'
 TcfUi.propTypes = {
   isMobile: PropTypes.bool,
   showVendors: PropTypes.bool,
-  isTablet: PropTypes.bool,
   lang: PropTypes.string,
   logo: PropTypes.string,
   onCloseModal: PropTypes.func,

--- a/demo/tcf/ui/demo/index.js
+++ b/demo/tcf/ui/demo/index.js
@@ -3,7 +3,6 @@ import React, {useState} from 'react'
 
 const TcfUiDemo = () => {
   const [isMobile, setIsMobile] = useState(false)
-  const [isTablet, setIsTablet] = useState(false)
   const [show, setShow] = useState(false)
   const [showInModalForMobile, setShowInModalForMobile] = useState(false)
   return (
@@ -11,7 +10,6 @@ const TcfUiDemo = () => {
       <button
         onClick={() => {
           setIsMobile(false)
-          setIsTablet(false)
         }}
       >
         Desktop
@@ -19,35 +17,28 @@ const TcfUiDemo = () => {
       <button
         onClick={() => {
           setIsMobile(true)
-          setIsTablet(false)
         }}
       >
         Mobile
       </button>
       <button
         onClick={() => {
-          setIsMobile(false)
-          setIsTablet(true)
-        }}
-      >
-        Tablet
-      </button>
-      <button
-        onClick={() => {
           setShow(true)
         }}
       >
-        Show vendors layer
+        Show Second layer
       </button>
       <button onClick={() => setShowInModalForMobile(prev => !prev)}>
-        {showInModalForMobile ? 'Show in Notification' : 'Show in Modal'}
+        {showInModalForMobile
+          ? 'Show first layer Notification variation'
+          : 'Show first layer Modal variation'}
       </button>
       <TcfUi
         lang="es"
         logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
         isMobile={isMobile}
-        isTablet={isTablet}
         showVendors={show}
+        onCloseModal={() => setShow(!show)}
         showInModalForMobile={showInModalForMobile}
       />
     </div>

--- a/demo/tcf/ui/demo/index.js
+++ b/demo/tcf/ui/demo/index.js
@@ -38,7 +38,7 @@ const TcfUiDemo = () => {
         logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
         isMobile={isMobile}
         showVendors={show}
-        onCloseModal={() => setShow(!show)}
+        onCloseModal={() => setShow(false)}
         showInModalForMobile={showInModalForMobile}
       />
     </div>


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->
*Update the flow between layers to work as this:
- UI is open by default (first layer appears):
   - second layer (purposes...) is configured to go back to first layer
   - third layer (vendors) configured to go back to second layer
- UI opened from the footer ("Gestionar Publicidad") or from the "Menú de usuario" (second layer appears) 
   - "go back" is configured to close the CMP

*Correct the demo behaviour (using the onCloseModal callback)

*Remove unused isTablet prop

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

https://jira.scmspain.com/browse/PSP-3357
https://jira.scmspain.com/browse/PSP-3352

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

Check it in the ui demo.
