### PR TITLE
Fix/ui api communication

### DIFF
--- a/components/tcf/services/src/application/Service.js
+++ b/components/tcf/services/src/application/Service.js
@@ -20,11 +20,15 @@ class Service {
   }
 
   saveUserConsent({purpose, vendor, specialFeatures}) {
-    this._saveUserConsentUseCase.execute({purpose, vendor, specialFeatures})
+    return this._saveUserConsentUseCase.execute({
+      purpose,
+      vendor,
+      specialFeatures
+    })
   }
 
   uiVisible({visible}) {
-    this._uiVisibleUseCase.execute({visible})
+    return this._uiVisibleUseCase.execute({visible})
   }
 }
 

--- a/components/tcf/services/src/application/service/SaveUserConsentUseCase.js
+++ b/components/tcf/services/src/application/service/SaveUserConsentUseCase.js
@@ -4,7 +4,7 @@ class SaveUserConsentUseCase {
   }
 
   execute({purpose, vendor, specialFeatures}) {
-    this._repository.saveUserConsent({purpose, vendor, specialFeatures})
+    return this._repository.saveUserConsent({purpose, vendor, specialFeatures})
   }
 }
 

--- a/components/tcf/services/src/application/service/UiVisibleUseCase.js
+++ b/components/tcf/services/src/application/service/UiVisibleUseCase.js
@@ -4,7 +4,7 @@ class UiVisibleUseCase {
   }
 
   execute({visible}) {
-    this._repository.uiVisible({visible})
+    return this._repository.uiVisible({visible})
   }
 }
 

--- a/components/tcf/services/src/infrastructure/Tcf/TcfRepository.js
+++ b/components/tcf/services/src/infrastructure/Tcf/TcfRepository.js
@@ -12,11 +12,11 @@ class TcfRepository {
   }
 
   saveUserConsent({purpose, vendor, specialFeatures}) {
-    this._tcfApi.saveUserConsent({purpose, vendor, specialFeatures})
+    return this._tcfApi.saveUserConsent({purpose, vendor, specialFeatures})
   }
 
   uiVisible({visible}) {
-    this._tcfApi.uiVisible({visible})
+    return this._tcfApi.uiVisible({visible})
   }
 }
 

--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -56,9 +56,9 @@ export default function TCFContainer({
   const handleOpenCookiepolicyLayer = () => {
     setShowLayer(3)
   }
-  const handleSaveUserConsent = ({purpose, vendor, specialFeatures}) => {
+  const handleSaveUserConsent = async ({purpose, vendor, specialFeatures}) => {
+    await saveUserConsent({purpose, vendor, specialFeatures})
     uiVisible({visible: false})
-    saveUserConsent({purpose, vendor, specialFeatures})
     onCloseModal && onCloseModal()
     setShowLayer(0)
   }

--- a/demo/tcf/ui/demo/index.js
+++ b/demo/tcf/ui/demo/index.js
@@ -1,10 +1,23 @@
 import TcfUi from '../../../../components/tcf/ui/src'
-import React, {useState} from 'react'
+import React, {useState, useEffect} from 'react'
 
 const TcfUiDemo = () => {
   const [isMobile, setIsMobile] = useState(false)
   const [show, setShow] = useState(false)
   const [showInModalForMobile, setShowInModalForMobile] = useState(false)
+  const [eventStatus, setEventStatus] = useState('empty')
+  useEffect(() => {
+    window.__tcfapi('addEventListener', 2, (tcData, success) => {
+      if (
+        success &&
+        (tcData.eventStatus === 'tcloaded' ||
+          tcData.eventStatus === 'useractioncomplete')
+      ) {
+        setEventStatus(tcData.eventStatus)
+        window.__tcfapi('removeEventListener', 2, () => null, tcData.listenerId)
+      }
+    })
+  })
   return (
     <div style={{height: '3500px'}}>
       <button
@@ -33,6 +46,9 @@ const TcfUiDemo = () => {
           ? 'Show first layer Notification variation'
           : 'Show first layer Modal variation'}
       </button>
+      <div>
+        <b>Event Status:</b> {eventStatus}
+      </div>
       <TcfUi
         lang="es"
         logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"

--- a/test/tcf/services/application/service/saveUserConsentUseCase.test.js
+++ b/test/tcf/services/application/service/saveUserConsentUseCase.test.js
@@ -46,8 +46,7 @@ describe('SaveUserConsentUseCase test', () => {
     const saveUserConsentUseCase = new SaveUserConsentUseCase({
       repository: tcfRepositoryMock
     })
-    const response = await saveUserConsentUseCase.execute(userConsent)
-    expect(response).toBe(undefined)
+    await saveUserConsentUseCase.execute(userConsent)
     expect(saveUserConsentSpy).toHaveBeenCalledTimes(1)
     expect(saveUserConsentSpy).toHaveBeenCalledWith(userConsent)
   })

--- a/test/tcf/services/application/service/uiVisibleUseCase.test.js
+++ b/test/tcf/services/application/service/uiVisibleUseCase.test.js
@@ -21,8 +21,7 @@ describe('UiVisibleUseCase test', () => {
     const uiVisibleUseCase = new UiVisibleUseCase({
       repository: tcfRepositoryMock
     })
-    const response = await uiVisibleUseCase.execute({visible})
-    expect(response).toBe(undefined)
+    await uiVisibleUseCase.execute({visible})
     expect(uiVisibleSpy).toHaveBeenCalledTimes(1)
     expect(uiVisibleSpy).toHaveBeenCalledWith({visible})
   })


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

When saving a consent, the consent must be saved in the cookie before notifying the state change, or it'll read the cookie value before having the new user's consent and so, will notify an empty TCData.
Here we can see that the `save` is ran after the last consent load (which has an empty value yet):

![image](https://user-images.githubusercontent.com/20399660/87555173-65f29b80-c6b5-11ea-94e5-e2c1a5c63743.png)


## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3363

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* when we save the consent, any registered event listener must receive a filled TCData within the `useractioncomplete` event

> the tcf/ui demo has been updated in order to demostrate this

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

Can be validated in the UI demo.


## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/WS3kQlip00vwV8CXwQ/giphy.gif)