### PR TITLE
fix(tcf/secondLayer): add color styling to spans inside sui buttons

### DIFF
--- a/components/tcf/secondLayer/src/components/tcf-secondLayer-vendors-user-decision/index.scss
+++ b/components/tcf/secondLayer/src/components/tcf-secondLayer-vendors-user-decision/index.scss
@@ -9,5 +9,8 @@ $base-class: '.sui-TcfSecondLayer-group';
   &-texts .sui-AtomButton {
     font-size: 12px;
     margin: 0 0 0 $m-m;
+    & span {
+      color: $c-primary;
+    }
   }
 }

--- a/components/tcf/secondLayer/src/index.scss
+++ b/components/tcf/secondLayer/src/index.scss
@@ -104,6 +104,9 @@ $base-class-modal: '#sui-TcfSecondLayerModal';
       @include media-breakpoint-up(s) {
         left: $ml-tcf-second-layer-modal;
       }
+      & span {
+        color: $c-primary;
+      }
     }
 
     &--buttons {


### PR DESCRIPTION
## Description
Style fixes to be able to start test in fc

## Solves ticket/s
https://jira.scmspain.com/browse/PSP-3378 that is a part of https://jira.scmspain.com/browse/PSP-3374

## Review steps
**Before**
![image](https://user-images.githubusercontent.com/26205284/87907077-2be21a80-ca64-11ea-8487-0df449433b5f.png)

**After**
![image](https://user-images.githubusercontent.com/26205284/87906887-c4c46600-ca63-11ea-9c84-5f4046dd9612.png)

##Review steps
Start the [server](https://github.mpi-internal.com/scmspain/frontend-fc--web-server) linking the necessary packages and forcing the Tcf component instead of the Cmp in the shared footer component.
`npm run dev -- --link-package=../frontend-fc--uilib-components/components/shared/tcf --link-package=../frontend-fc--uilib-components/components/shared/footer --link-package=../../adevinta-spain-components/components/tcf/ui --link-package=../../adevinta-spain-components/components/tcf/secondLayer`
