### PR TITLE
Fix/protect against vendor list errors

### DIFF
--- a/components/tcf/secondLayer/src/index.js
+++ b/components/tcf/secondLayer/src/index.js
@@ -58,7 +58,9 @@ export default function TcfSecondLayer({
         specialFeatures: userConsent.specialFeatures
       })
     }
-    getVendorListAndConsent()
+    getVendorListAndConsent().catch(() => {
+      setModalOpen(false)
+    })
   }, [getVendorList, loadUserConsent])
 
   const handleCloseModal = () => {

--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -30,7 +30,9 @@ export default function TCFContainer({
         setShowLayer(1)
       }
     }
-    checkConsentStatus()
+    checkConsentStatus().catch(() => {
+      setShowLayer(0)
+    })
   }, [])
 
   const handleOpenSecondLayer = () => {

--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import React, {Suspense, useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {useConsent} from '@s-ui/react-tcf-services'


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

In case we cannot get the remote vendor list due to HTTP errors or whatever, the modals should not be opened in order to avoid blocking the user's screen with an unusable form.

![image](https://user-images.githubusercontent.com/20399660/87950329-746ef780-caa7-11ea-9116-a5ad1bf6df31.png)


## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3396

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* on the first layer evaluation, if loading the consent fails, the modal is hidden
* on the second layer evaluation, if loading the consent or the vendor list fails, the modal is hidden 
* on both cases, nothing can be stored in the cookie, so "empty / invalid" consent will be retrieved from TCF and so, the "tcloaded" or the "useractioncomplete" will never be raised.

![image](https://user-images.githubusercontent.com/20399660/87950787-07a82d00-caa8-11ea-9c13-cdafd9ebeefe.png)


## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

* tested in local using the demo and using Charles to map remotely 
  - from: https://a.dcdn.es/borostcf/v2/vendorlist/LATEST?language=es 
  - to:     https://a.dcdn.es/borostcf/v2/vendorlist/LATEST?language=xx
## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif)