### PR TITLE
Feature/it translations tcf

### DIFF
--- a/components/tcf/ui/src/FirstLayer/settings.js
+++ b/components/tcf/ui/src/FirstLayer/settings.js
@@ -5,8 +5,14 @@ const DEFAULT_I18N = {
     '<h5 class="sui-TcfFirstLayer-title">Nos preocupamos por tu privacidad</h5><p>Utilizamos cookies e identificadores propios y de terceros con el propósito de almacenar o acceder a información en tu dispositivo, recabar datos personales sobre la audiencia para desarrollar y mejorar productos así como mostrar y medir anuncios propios y/o de terceros y/o contenido personalizados basándonos en tu navegación (por ejemplo páginas visitadas). </p><p>Algunos de estos propósitos incluyen la geolocalización precisa, el análisis de las características del dispositivo para distinguir los usuarios, el cotejo y combinación de datos off line y el vínculo de diferentes dispositivos.</p><p>En cualquier caso utilizaremos cookies para garantizar la seguridad, evitar fraudes, depurar errores y servir técnicamente anuncios o contenidos. Si continúas navegando aceptas su uso de cookies para esta web o aplicación. Podrás modificar tu elección en “Gestionar la Privacidad” en tu área de usuario o configurar su uso pulsando “Configurar”. Más info  <a class="sui-TcfFirstLayer-link" href="#">Política de cookies.</a></p>'
 }
 
+const IT_I18N = {
+  CONTINUE_NAVIGATION_BUTTON: 'Continua la navigazione',
+  CONFIGURE_BUTTON: 'Configura',
+  BODY: `<h5 class="sui-TcfFirstLayer-title">La tua privacy è importante</h5><p>Utilizziamo cookies e identificatori di prima o terza parte allo scopo di immagazzinare o accedere alle informazioni sul tuo dispositivo, per raccogliere dati personali degli utenti per sviluppare e migliorare prodotti, nonché per visualizzare e misurare pubblicità nostra e/o di terzi e/o contenuti personalizzati basati sulla tua navigazione (ad esempio le pagine visitate). </p><p>Alcuni di questi scopi includono la geolocalizzazione precisa, l'analisi delle caratteristiche del dispositivo per distinguere gli utenti, la raccolta e la combinazione di dati offline e il collegamento di diversi dispositivi.</p><p>n ogni caso, utilizzeremo cookies per garantire la sicurezza, evitare truffe, errori di debug e tecnicamente servire annunci o contenuti. Se continui a navigare accetti l'uso dei cookie per questo sito Web o questa applicazione. Puoi modificare la tua scelta in "Gestisci privacy" nella tua area utente o configurarne l'uso premendo "Configura". Maggiori informazioni  <a class="sui-TcfFirstLayer-link" href="#">Politica sulle cookies.</a></p>`
+}
+
 export const I18N = {
-  it: DEFAULT_I18N,
+  it: IT_I18N,
   es: DEFAULT_I18N,
   en: DEFAULT_I18N,
   ca: DEFAULT_I18N,

--- a/components/tcf/ui/src/SecondLayer/settings.js
+++ b/components/tcf/ui/src/SecondLayer/settings.js
@@ -35,8 +35,45 @@ const DEFAULT_I18N = {
   }
 }
 
+const IT_I18N = {
+  LEGITIMATE_INTEREST_COPY: 'Interesse legittimo',
+  CONSENT_COPY: '',
+  GO_BACK_BUTTON: 'Indietro',
+  ACCEPT_BUTTON: 'Accetta',
+  DISABLE_BUTTON: 'Rifiuta tutto',
+  ENABLE_BUTTON: 'Accetta tutto',
+  SECOND_LAYER: {
+    TITLE: 'Configurazione',
+    TEXT:
+      'Cliccando, acconsenti al trattamento dei tuoi dati per questo sito web (o app), navigatore e dispositivo con le seguenti finalità:',
+    PURPOSES_TITLE: 'Finalità',
+    SPECIAL_PURPOSES_TITLE: 'Finalità speciali',
+    FEATURES_TITLE: 'Caratteristiche',
+    SPECIAL_FEATURES_TITLE: 'Caratteristiche speciali',
+    PARTNERS_LINK: 'Lista dei partner',
+    READ_MORE: 'Mostra altro',
+    READ_LESS: 'Nascondi'
+  },
+  VENDOR_PAGE: {
+    TITLE: 'Cookie di prima o terza parte per la pubblicità segmentata',
+    TEXT:
+      'Ci preoccupiamo molto della tua privacy, per questo motivo vogliamo informarti delle finalità perseguite dai cookie per la pubblicità personalizzata, e farti sapere con chi stiamo condividendo le tue informazioni. Potrai inoltre definire le finalità e le terze parti con le quali accetti o meno di condividere i tuoi dati di navigazione, di posizione e i tuoi dati personali. Tieni presente che questi cookie sono legati alla tua sessione di navigazione, quindi se aggiorni i tuoi cookie, cambiando dispositivo o connettendoti da un altro browser, dovrai riconfigurare le tue preferenze.',
+    GROUPS: {
+      TITLE: 'Lista di partners con cui lavoriamo',
+      EXPANDED: {
+        PURPOSES: 'Finalità',
+        LEGITIMATE_INTEREST_PURPOSES: 'Interesse legittimo in:',
+        SPECIAL_PURPOSES: 'Finalità speciali',
+        FEATURES: 'Caratteristiche',
+        SPECIAL_FEATURES: 'Caratteristiche speciali',
+        POLICY_URL: 'Privacy Policy'
+      }
+    }
+  }
+}
+
 export const I18N = {
-  it: DEFAULT_I18N,
+  it: IT_I18N,
   es: DEFAULT_I18N,
   en: DEFAULT_I18N,
   ca: DEFAULT_I18N,

--- a/demo/tcf/ui/demo/index.js
+++ b/demo/tcf/ui/demo/index.js
@@ -5,6 +5,7 @@ const TcfUiDemo = () => {
   const [isMobile, setIsMobile] = useState(false)
   const [show, setShow] = useState(false)
   const [showInModalForMobile, setShowInModalForMobile] = useState(false)
+  const [langToIt, setLangToIt] = useState(false)
   const [eventStatus, setEventStatus] = useState('empty')
   useEffect(() => {
     window.__tcfapi('addEventListener', 2, (tcData, success) => {
@@ -46,17 +47,32 @@ const TcfUiDemo = () => {
           ? 'Show first layer Notification variation'
           : 'Show first layer Modal variation'}
       </button>
+      <button onClick={() => setLangToIt(prev => !prev)}>
+        {langToIt ? 'Spanish' : 'Italian'}
+      </button>
       <div>
         <b>Event Status:</b> {eventStatus}
       </div>
-      <TcfUi
-        lang="es"
-        logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
-        isMobile={isMobile}
-        showVendors={show}
-        onCloseModal={() => setShow(false)}
-        showInModalForMobile={showInModalForMobile}
-      />
+      {!langToIt && (
+        <TcfUi
+          lang="es"
+          logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
+          isMobile={isMobile}
+          showVendors={show}
+          onCloseModal={() => setShow(false)}
+          showInModalForMobile={showInModalForMobile}
+        />
+      )}
+      {langToIt && (
+        <TcfUi
+          lang="it"
+          logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
+          isMobile={isMobile}
+          showVendors={show}
+          onCloseModal={() => setShow(false)}
+          showInModalForMobile={showInModalForMobile}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Description
Add texts in italian for italian translation option.

## Solves ticket/s
https://jira.scmspain.com/browse/PSP-3331

## Expected behavior
When you set it language in the TcfUi component all texts are in italian
<img width="1058" alt="Screenshot 2020-07-22 at 08 24 36" src="https://user-images.githubusercontent.com/26205284/88143256-31bc3500-cbf7-11ea-8bf8-efb3dd76afe5.png">
<img width="805" alt="Screenshot 2020-07-22 at 08 23 55" src="https://user-images.githubusercontent.com/26205284/88143263-3680e900-cbf7-11ea-9893-d66d27631d60.png">
<img width="805" alt="Screenshot 2020-07-22 at 08 24 10" src="https://user-images.githubusercontent.com/26205284/88143272-397bd980-cbf7-11ea-95ce-b343bddf90bb.png">

## Further considerations
To be able to see the vendor list in italian also I had to link the tcf services and boros-tcf library when running the demo. 
