### PR TITLE
Fix/saving all from scoped consent

### DIFF
--- a/components/tcf/services/src/application/Service.js
+++ b/components/tcf/services/src/application/Service.js
@@ -25,11 +25,21 @@ class Service {
     return this._saveUserConsentUseCase.execute()
   }
 
-  updateUserConsent({purpose, vendor, specialFeatures}) {
+  updateUserConsent({
+    purpose,
+    vendor,
+    specialFeatures,
+    allPurposes,
+    allVendors,
+    allSpecialFeatures
+  }) {
     return this._updateUserConsentUseCase.execute({
       purpose,
       vendor,
-      specialFeatures
+      specialFeatures,
+      allPurposes,
+      allVendors,
+      allSpecialFeatures
     })
   }
 

--- a/components/tcf/services/src/application/service/UpdateUserConsentUseCase.js
+++ b/components/tcf/services/src/application/service/UpdateUserConsentUseCase.js
@@ -3,11 +3,21 @@ export class UpdateUserConsentUseCase {
     this._repository = repository
   }
 
-  execute({purpose, vendor, specialFeatures}) {
+  execute({
+    purpose,
+    vendor,
+    specialFeatures,
+    allPurposes,
+    allVendors,
+    allSpecialFeatures
+  }) {
     return this._repository.updateUserConsent({
       purpose,
       vendor,
-      specialFeatures
+      specialFeatures,
+      allPurposes,
+      allVendors,
+      allSpecialFeatures
     })
   }
 }

--- a/components/tcf/services/src/index.js
+++ b/components/tcf/services/src/index.js
@@ -18,8 +18,22 @@ function ConsentProvider({language, isMobile, scope, children}) {
     return defaultScope
   }
   const saveUserConsent = () => service.current.saveUserConsent()
-  const updateUserConsent = ({purpose, vendor, specialFeatures}) =>
-    service.current.updateUserConsent({purpose, vendor, specialFeatures})
+  const updateUserConsent = ({
+    purpose,
+    vendor,
+    specialFeatures,
+    allPurposes,
+    allVendors,
+    allSpecialFeatures
+  }) =>
+    service.current.updateUserConsent({
+      purpose,
+      vendor,
+      specialFeatures,
+      allPurposes,
+      allVendors,
+      allSpecialFeatures
+    })
   const uiVisible = ({visible}) => service.current.uiVisible({visible})
   return (
     <ConsentContext.Provider

--- a/components/tcf/services/src/infrastructure/tcf/factory.js
+++ b/components/tcf/services/src/infrastructure/tcf/factory.js
@@ -3,6 +3,6 @@ import TcfApiInitializer from '@adv-ui/boros-tcf'
 
 const tcfApi = TcfApiInitializer.init()
 
-export function tcfRepositoryFactory({language}) {
-  return new TcfRepository({tcfApi, language})
+export function tcfRepositoryFactory({language, scope}) {
+  return new TcfRepository({tcfApi, language, scope})
 }

--- a/test/tcf/services/application/service/updateUserConsentUseCase.test.js
+++ b/test/tcf/services/application/service/updateUserConsentUseCase.test.js
@@ -1,0 +1,123 @@
+/* eslint-env jest */
+import {TcfRepositoryMock} from '../../helpers/TcfRepositoryMock'
+import {UpdateUserConsentUseCase} from '../../../../../components/tcf/services/src/application/service/UpdateUserConsentUseCase'
+import {LoadUserConsentUseCase} from '../../../../../components/tcf/services/src/application/service/LoadUserConsentUseCase'
+describe('UpdateUserConsentUseCase test', () => {
+  const testPurposes = [1, 2, 3]
+  const testVendors = [1, 2, 3]
+  const testSpecialFeatures = [1, 2]
+
+  const mockConsent = ({accepted = false} = {}) => {
+    const consent = {
+      isNew: true,
+      purpose: {consents: {}, legitimateInterests: {}},
+      vendor: {consents: {}, legitimateInterests: {}},
+      specialFeatures: {}
+    }
+    testPurposes.forEach(k => {
+      consent.purpose.consents[k] = accepted
+      consent.purpose.legitimateInterests[k] = accepted
+    })
+    testVendors.forEach(k => {
+      consent.vendor.consents[k] = accepted
+      consent.vendor.legitimateInterests[k] = accepted
+    })
+    testSpecialFeatures.forEach(k => {
+      consent.specialFeatures[k] = accepted
+    })
+    return consent
+  }
+
+  const mockUseCases = async ({initialConsent = mockConsent(), scope} = {}) => {
+    const borosMethods = {
+      saveUserConsent: () => Promise.resolve(null),
+      getVendorList: () =>
+        Promise.resolve({vendors: {}, purposes: {}, specialFeatures: {}}),
+      loadUserConsent: () => Promise.resolve(initialConsent)
+    }
+    const borosTCFMock = {
+      init: () => borosMethods
+    }
+    const tcfRepositoryMock = new TcfRepositoryMock({
+      tcfApi: borosTCFMock.init(),
+      scope
+    })
+    const loadUserConsentUseCase = new LoadUserConsentUseCase({
+      repository: tcfRepositoryMock
+    })
+    const updateUserConsentUseCase = new UpdateUserConsentUseCase({
+      repository: tcfRepositoryMock
+    })
+    await loadUserConsentUseCase.execute()
+    return {loadUserConsentUseCase, updateUserConsentUseCase}
+  }
+
+  it('should update consent with given values', async () => {
+    const initialConsent = mockConsent({accepted: true})
+    const {
+      loadUserConsentUseCase,
+      updateUserConsentUseCase
+    } = await mockUseCases({
+      initialConsent
+    })
+    const givenUpdate = false
+    const modifiedConsent = mockConsent({accepted: givenUpdate})
+    updateUserConsentUseCase.execute({...modifiedConsent})
+    const consent = await loadUserConsentUseCase.execute()
+    const validateExpected = node =>
+      Object.values(node).every(value => value === givenUpdate)
+    expect(validateExpected(consent.purpose.consents)).toBeTruthy()
+    expect(validateExpected(consent.purpose.legitimateInterests)).toBeTruthy()
+    expect(validateExpected(consent.vendor.consents)).toBeTruthy()
+    expect(validateExpected(consent.vendor.legitimateInterests)).toBeTruthy()
+    expect(validateExpected(consent.specialFeatures)).toBeTruthy()
+  })
+  it('should update consent applying all values', async () => {
+    const initialConsent = mockConsent({accepted: false})
+    const {
+      loadUserConsentUseCase,
+      updateUserConsentUseCase
+    } = await mockUseCases({
+      initialConsent
+    })
+    updateUserConsentUseCase.execute({
+      ...initialConsent,
+      allPurposes: true,
+      allVendors: true,
+      allSpecialFeatures: true
+    })
+    const consent = await loadUserConsentUseCase.execute()
+    const validateExpected = node =>
+      Object.values(node).every(value => value === true)
+    expect(validateExpected(consent.purpose.consents)).toBeTruthy()
+    expect(validateExpected(consent.purpose.legitimateInterests)).toBeTruthy()
+    expect(validateExpected(consent.vendor.consents)).toBeTruthy()
+    expect(validateExpected(consent.vendor.legitimateInterests)).toBeTruthy()
+    expect(validateExpected(consent.specialFeatures)).toBeTruthy()
+  })
+  it('should use the scoped consent', async () => {
+    const givenScope = {
+      purposes: [2],
+      specialFeatures: [1]
+    }
+    const initialConsent = mockConsent({accepted: false})
+    const {
+      loadUserConsentUseCase,
+      updateUserConsentUseCase
+    } = await mockUseCases({
+      initialConsent,
+      scope: givenScope
+    })
+    updateUserConsentUseCase.execute({
+      ...initialConsent,
+      allPurposes: true,
+      allVendors: true,
+      allSpecialFeatures: true
+    })
+    const consent = await loadUserConsentUseCase.execute()
+    expect(consent.purpose.consents[1]).toBeFalsy()
+    expect(consent.purpose.consents[2]).toBeTruthy()
+    expect(consent.specialFeatures[1]).toBeTruthy()
+    expect(consent.specialFeatures[2]).toBeFalsy()
+  })
+})

--- a/test/tcf/services/helpers/TcfRepositoryMock.js
+++ b/test/tcf/services/helpers/TcfRepositoryMock.js
@@ -1,7 +1,7 @@
 import {TcfRepository} from '../../../../components/tcf/services/src/infrastructure/tcf/TcfRepository'
 class TcfRepositoryMock extends TcfRepository {
-  constructor({tcfApi}) {
-    super({tcfApi})
+  constructor({tcfApi, scope}) {
+    super({tcfApi, scope})
   }
 }
 


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

This PR fixes updating the in-memory consent to the accepted update values according to the "scoped consent", in order to filter which values can be updated (p.ex. specialFeature 2 actually should never be updated to a true consent) 

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3415

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* in first and second layers: accepting all will save "true" only for all consents accepted in the scope

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

* tested in local demo

After accepting all:

![image](https://user-images.githubusercontent.com/20399660/88166926-5674d480-cc18-11ea-8432-306086db0b51.png)

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/TIcMOKgkoCVtTcpIFb/giphy.gif)