### PR TITLE
Feature/improve gvl languages

### DIFF
--- a/components/tcf/services/src/application/Service.js
+++ b/components/tcf/services/src/application/Service.js
@@ -13,8 +13,8 @@ class Service {
     this._uiVisibleUseCase = uiVisibleUseCase
   }
 
-  getVendorList({language = 'es'} = {}) {
-    return this._getVendorListUseCase.execute({language})
+  getVendorList() {
+    return this._getVendorListUseCase.execute()
   }
 
   loadUserConsent() {

--- a/components/tcf/services/src/application/service/GetVendorListUseCase.js
+++ b/components/tcf/services/src/application/service/GetVendorListUseCase.js
@@ -3,8 +3,8 @@ class GetVendorListUseCase {
     this._repository = repository
   }
 
-  execute({language} = {}) {
-    return this._repository.getVendorList({language})
+  execute() {
+    return this._repository.getVendorList()
   }
 }
 

--- a/components/tcf/services/src/infrastructure/tcf/TcfRepository.js
+++ b/components/tcf/services/src/infrastructure/tcf/TcfRepository.js
@@ -1,14 +1,13 @@
 class TcfRepository {
-  constructor({tcfApi, language = 'es', scope = {}}) {
+  constructor({tcfApi, scope = {}}) {
     this._tcfApi = tcfApi
-    this._language = language
     this._scope = scope
     this._cachedConsent = null
     this._data = {}
   }
 
   getVendorList() {
-    return this._tcfApi.getVendorList({language: this._language})
+    return this._tcfApi.getVendorList()
   }
 
   loadUserConsent() {

--- a/components/tcf/services/src/infrastructure/tcf/factory.js
+++ b/components/tcf/services/src/infrastructure/tcf/factory.js
@@ -1,8 +1,7 @@
 import {TcfRepository} from './TcfRepository'
 import TcfApiInitializer from '@adv-ui/boros-tcf'
 
-const tcfApi = TcfApiInitializer.init()
-
 export function tcfRepositoryFactory({language, scope}) {
-  return new TcfRepository({tcfApi, language, scope})
+  const tcfApi = TcfApiInitializer.init({language})
+  return new TcfRepository({tcfApi, scope})
 }

--- a/demo/tcf/ui/context.js
+++ b/demo/tcf/ui/context.js
@@ -1,0 +1,12 @@
+export default () => ({
+  default: {
+    config: {
+      language: 'es'
+    }
+  },
+  italian: {
+    config: {
+      language: 'it'
+    }
+  }
+})

--- a/demo/tcf/ui/demo/index.js
+++ b/demo/tcf/ui/demo/index.js
@@ -1,11 +1,12 @@
 import TcfUi from '../../../../components/tcf/ui/src'
-import React, {useState, useEffect} from 'react'
+import React, {useState, useEffect, useContext} from 'react'
+import Context from '@s-ui/react-context'
 
 const TcfUiDemo = () => {
+  const {config = {}} = useContext(Context)
   const [isMobile, setIsMobile] = useState(false)
   const [show, setShow] = useState(false)
   const [showInModalForMobile, setShowInModalForMobile] = useState(false)
-  const [langToIt, setLangToIt] = useState(false)
   const [eventStatus, setEventStatus] = useState('empty')
   useEffect(() => {
     window.__tcfapi('addEventListener', 2, (tcData, success) => {
@@ -47,32 +48,17 @@ const TcfUiDemo = () => {
           ? 'Show first layer Notification variation'
           : 'Show first layer Modal variation'}
       </button>
-      <button onClick={() => setLangToIt(prev => !prev)}>
-        {langToIt ? 'Spanish' : 'Italian'}
-      </button>
       <div>
         <b>Event Status:</b> {eventStatus}
       </div>
-      {!langToIt && (
-        <TcfUi
-          lang="es"
-          logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
-          isMobile={isMobile}
-          showVendors={show}
-          onCloseModal={() => setShow(false)}
-          showInModalForMobile={showInModalForMobile}
-        />
-      )}
-      {langToIt && (
-        <TcfUi
-          lang="it"
-          logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
-          isMobile={isMobile}
-          showVendors={show}
-          onCloseModal={() => setShow(false)}
-          showInModalForMobile={showInModalForMobile}
-        />
-      )}
+      <TcfUi
+        lang={config.language}
+        logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
+        isMobile={isMobile}
+        showVendors={show}
+        onCloseModal={() => setShow(false)}
+        showInModalForMobile={showInModalForMobile}
+      />
     </div>
   )
 }

--- a/test/tcf/services/application/service/getVendorListUseCase.test.js
+++ b/test/tcf/services/application/service/getVendorListUseCase.test.js
@@ -38,16 +38,4 @@ describe('GetVendorListUseCase test', () => {
     expect(vendorList).toBe(givenVendorList)
     expect(getVendorListSpy).toHaveBeenCalledTimes(1)
   })
-  it('should pass correct language value when execute', async () => {
-    const tcfRepositoryMock = new TcfRepositoryMock({
-      tcfApi: borosTCFMock.init()
-    })
-    const getVendorListUseCase = new GetVendorListUseCase({
-      repository: tcfRepositoryMock
-    })
-    const vendorList = await getVendorListUseCase.execute({language: 'es'})
-    expect(vendorList).toBe(givenVendorList)
-    expect(getVendorListSpy).toHaveBeenCalledTimes(1)
-    expect(getVendorListSpy).toHaveBeenCalledWith({language: 'es'})
-  })
 })


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

We want to load a GVL in a specific language directly in a single HTTP request.
In order to do that, `boros-tcf` has been updated to enable its initalization with a language parameter.
This PR changes the usage of BorosTcf when loading the vendor list to use the given language from the ConsentProvider initialization directly to initialize BorosTcf with the same language.

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3418

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

With spanish language:
![image](https://user-images.githubusercontent.com/20399660/88285260-12083800-ccef-11ea-95be-98d73fa500aa.png)

With italian language:
![image](https://user-images.githubusercontent.com/20399660/88285325-2c421600-ccef-11ea-9def-7ac82b4a66f8.png)


## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

Tested locally:
`HOST=local.schibsted.io npm run dev tcf/ui -- --link-package=components/tcf/services`

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/12hPQk7oAsk5UY/giphy.gif)