### PR TITLE
feat(form/builder): check min and max constraints when dealing with l…

### DIFF
--- a/components/form/builder/src/Standard/fn-utils.js
+++ b/components/form/builder/src/Standard/fn-utils.js
@@ -1,0 +1,5 @@
+const removeAllDots = string => string.replace(/\./g, '')
+const replaceFirstCommaWithDot = string => string.replace(',', '.')
+const removeAllCommas = string => string.replace(/,/g, '')
+export const fromStringToLocaleFloat = string =>
+  parseFloat(removeAllCommas(replaceFirstCommaWithDot(removeAllDots(string))))

--- a/components/form/builder/src/Standard/index.js
+++ b/components/form/builder/src/Standard/index.js
@@ -118,7 +118,7 @@ const checkConstraintsFromField = field => {
 
   // cutom validation: min html attributes in input type text are not nativelly supported
   if (
-    // if is a field text and display multiline
+    // if is a field text and display text or default
     (field.type === FIELDS.TEXT &&
       field.display === DISPLAYS[FIELDS.TEXT].TEXT) ||
     field.display === DISPLAYS[FIELDS.TEXT].DEFAULT
@@ -131,9 +131,9 @@ const checkConstraintsFromField = field => {
     if (inputValueAsNumber < parseFloat(inputHasMin?.property?.min))
       errorMessages = [...errorMessages, inputHasMin.message]
   }
-  // cutom validation: min html attributes in input type text are not nativelly supported
+  // cutom validation: max html attributes in input type text are not nativelly supported
   if (
-    // if is a field text and display multiline
+    // if is a field text and display text or default
     (field.type === FIELDS.TEXT &&
       field.display === DISPLAYS[FIELDS.TEXT].TEXT) ||
     field.display === DISPLAYS[FIELDS.TEXT].DEFAULT

--- a/components/form/builder/src/Standard/index.js
+++ b/components/form/builder/src/Standard/index.js
@@ -1,7 +1,7 @@
 // map the DSL standard to JS: https://docs.mpi-internal.com/scmspain/all--lib-form-builder-docs/form-specification/field/
 
 import {pickFieldById, fieldsNamesInOrderOfDefinition} from '../reducer/fields'
-
+import {fromStringToLocaleFloat} from './fn-utils'
 const FIELDS = {
   TEXT: 'text',
   NUMERIC: 'numeric',
@@ -116,6 +116,37 @@ const checkConstraintsFromField = field => {
       errorMessages = [checkboxShouldBeTrueConstraint.message, ...errorMessages]
   }
 
+  // cutom validation: min html attributes in input type text are not nativelly supported
+  if (
+    // if is a field text and display multiline
+    (field.type === FIELDS.TEXT &&
+      field.display === DISPLAYS[FIELDS.TEXT].TEXT) ||
+    field.display === DISPLAYS[FIELDS.TEXT].DEFAULT
+  ) {
+    const inputHasMin = field.constraints?.find(
+      constraint => constraint.property?.min
+    )
+    const inputValueAsNumber = fromStringToLocaleFloat(elementNode?.value)
+
+    if (inputValueAsNumber < parseFloat(inputHasMin?.property?.min))
+      errorMessages = [...errorMessages, inputHasMin.message]
+  }
+  // cutom validation: min html attributes in input type text are not nativelly supported
+  if (
+    // if is a field text and display multiline
+    (field.type === FIELDS.TEXT &&
+      field.display === DISPLAYS[FIELDS.TEXT].TEXT) ||
+    field.display === DISPLAYS[FIELDS.TEXT].DEFAULT
+  ) {
+    const inputHasMax = field.constraints?.find(
+      constraint => constraint.property?.max
+    )
+    const inputValueAsNumber = fromStringToLocaleFloat(elementNode?.value)
+
+    if (inputValueAsNumber > parseFloat(inputHasMax?.property?.max)) {
+      errorMessages = [...errorMessages, inputHasMax.message]
+    }
+  }
   return errorMessages
 }
 


### PR DESCRIPTION
### Context/Problem

When using `<input type="number" />`:

1. Browsers have a 'bug' or 'behavior' that is not helping us: `Chrome's default behaviour is to empty the value when a user enters a dot into an input element of type number.
2. Also, when a Spanish/European user enters a `comma` is automatically converted as a dot. So it is impossible to express decimal numbers in a Spanish way.
3. Or if a Spanish user writes: 1.000,23 the input returns also an empty string.
4. Moreover if the user for example writes: 1.23. the input also returns empty string.

What's happening:
- 1000 => 1000 => It is ok for Spain
- 1.000 => 1.000 => It is ok for Spain
- 1,000 => 1.000 => It is NOT ok for Spain
- 1.000,23 => '' => It is NOT ok for Spain
- 1,000.12 => '' => It is not a Spanish number but we can gracefully convert it to 1000,12 in Spanish, if input returned something but is also returning an empty string

Check this codepen if you want to play around the input of type number as see what it returns: https://codepen.io/whazam/pen/oOWxPK

### Solution

So, the ultimate solution is to use `type: text` instead of `type: number` in the input and then (if necessary) apply the localized rules to translate the localized string that the user entered into a number (probably your server understands only 'Engilsh' way) and send it to some backend service.

Until here you don't need some changes in the form builder.

But If you want to use the `min` and `max` constrains supported in all browsers for input type:number with an input of type:text it is not supported.

So here is the polyfill :D 