### PR TITLE
fix header color to white

### DIFF
--- a/components/tcf/ui/src/FirstLayer/index.scss
+++ b/components/tcf/ui/src/FirstLayer/index.scss
@@ -91,6 +91,9 @@ $base-class-modal: '#sui-TcfFirstLayerModal';
   .sui-MoleculeNotification {
     background-color: $c-white;
     box-shadow: $bxsh-tcf-first-layer;
+    &-content {
+      background-color: $c-white;
+    }
   }
 }
 

--- a/components/tcf/ui/src/SecondLayer/index.scss
+++ b/components/tcf/ui/src/SecondLayer/index.scss
@@ -45,6 +45,7 @@ $base-class-modal: '#sui-TcfSecondLayerModal';
 
   .sui-MoleculeModal-header {
     padding: $p-l 0 $p-l $ml-tcf-second-layer-modal-mobile;
+    background-color: $c-white;
     @include media-breakpoint-up(s) {
       padding: $p-xxl 0 $p-xxl $ml-tcf-second-layer-modal;
     }

--- a/components/tcf/ui/src/SecondLayer/index.scss
+++ b/components/tcf/ui/src/SecondLayer/index.scss
@@ -2,11 +2,11 @@
 @import '~@s-ui/react-atom-button/lib/index';
 @import '~@s-ui/react-molecule-modal/lib/index';
 @import '~@s-ui/react-atom-switch/lib/index';
-@import './components/iconClose';
-@import './components/tcf-secondLayer-decision-group';
-@import './components/tcf-secondLayer-user-decision';
-@import './components/tcf-secondLayer-vendors-user-decision';
-@import './components/tcf-secondLayer-legal-expandedContent';
+@import './components/iconClose/index';
+@import './components/tcf-secondLayer-decision-group/index';
+@import './components/tcf-secondLayer-user-decision/index';
+@import './components/tcf-secondLayer-vendors-user-decision/index';
+@import './components/tcf-secondLayer-legal-expandedContent/index';
 
 $fz-tcf-second-layer-base: $fz-s !default; // 14px
 $fz-tcf-second-layer-mobile: $fz-xs !default; // 12px


### PR DESCRIPTION
## Description
During the integration of TCF in IJ the background color of the modal header was the primary of IJ
<img width="857" alt="Screenshot 2020-07-29 at 10 58 52" src="https://user-images.githubusercontent.com/45286922/88784806-c17e5800-d190-11ea-80d5-f3d752012fb8.png">

During the integration in CN/MN the background color of the first layer was grey
![cn-desktop-firstLayer](https://user-images.githubusercontent.com/45286922/88925365-b6045d00-d274-11ea-8480-84c147ed75e6.png)

## GOAL

Fix the color to white according UX specs

<img width="844" alt="ij-desktop-secondLayer" src="https://user-images.githubusercontent.com/45286922/88784903-d9ee7280-d190-11ea-80e6-6043e0117da4.png">

![cn-desktop-firstLayer-white](https://user-images.githubusercontent.com/45286922/88925320-a7b64100-d274-11ea-9b97-66904a8230e3.png)
