### PR TITLE
Feature/disable toogles

### DIFF
--- a/components/tcf/services/src/infrastructure/tcf/TcfRepository.js
+++ b/components/tcf/services/src/infrastructure/tcf/TcfRepository.js
@@ -18,28 +18,9 @@ class TcfRepository {
   async _initializeConsent() {
     const userConsent = await this._tcfApi.loadUserConsent()
     if (userConsent.isNew) {
-      const vendorList = await this.getVendorList()
       userConsent.purpose = {consents: {}, legitimateInterests: {}}
       userConsent.vendor = {consents: {}, legitimateInterests: {}}
       userConsent.specialFeatures = {}
-
-      this._scope.purposes =
-        this._scope.purposes || Object.keys(vendorList.purposes)
-      this._scope.purposes.forEach(key => {
-        userConsent.purpose.consents[key] = true
-        userConsent.purpose.legitimateInterests[key] = true
-      })
-
-      Object.keys(vendorList.vendors).forEach(key => {
-        userConsent.vendor.consents[key] = true
-        userConsent.vendor.legitimateInterests[key] = true
-      })
-
-      this._scope.specialFeatures =
-        this._scope.specialFeatures || Object.keys(vendorList.specialFeatures)
-      this._scope.specialFeatures.forEach(
-        key => (userConsent.specialFeatures[key] = true)
-      )
     }
     this._data = userConsent
     return this._data

--- a/components/tcf/services/src/infrastructure/tcf/TcfRepository.js
+++ b/components/tcf/services/src/infrastructure/tcf/TcfRepository.js
@@ -18,9 +18,13 @@ class TcfRepository {
   async _initializeConsent() {
     const userConsent = await this._tcfApi.loadUserConsent()
     if (userConsent.isNew) {
+      const vendorList = await this.getVendorList()
       userConsent.purpose = {consents: {}, legitimateInterests: {}}
       userConsent.vendor = {consents: {}, legitimateInterests: {}}
       userConsent.specialFeatures = {}
+      Object.keys(vendorList.vendors).forEach(key => {
+        userConsent.vendor.legitimateInterests[key] = true
+      })
     }
     this._data = userConsent
     return this._data

--- a/components/tcf/ui/src/FirstLayer/index.js
+++ b/components/tcf/ui/src/FirstLayer/index.js
@@ -79,9 +79,11 @@ export default function TcfFirstLayer({
   }
 
   const handleSaveExitClick = async () => {
-    const userConsent = await loadUserConsent()
-    const vendorList = await getVendorList()
-    const scope = await getScope()
+    const [userConsent, vendorList, scope] = await Promise.all([
+      loadUserConsent(),
+      getVendorList(),
+      getScope()
+    ])
     scope.purposes = scope.purposes || Object.keys(vendorList.purposes)
     scope.purposes.forEach(key => {
       userConsent.purpose.consents[key] = true

--- a/components/tcf/ui/src/FirstLayer/index.js
+++ b/components/tcf/ui/src/FirstLayer/index.js
@@ -13,13 +13,21 @@ const SCROLL_TO_ACCEPT = 250
 
 export default function TcfFirstLayer({
   logo,
-  saveUserConsent,
-  openSecondLayer,
-  openCookiepolicyLayer,
+  onSaveUserConsent,
+  onOpenSecondLayer,
+  onOpenCookiePolicyLayer,
   showInModalForMobile = false
 }) {
-  const {isMobile, language, loadUserConsent, updateUserConsent} = useConsent()
+  const {
+    isMobile,
+    language,
+    loadUserConsent,
+    updateUserConsent,
+    getVendorList,
+    getScope
+  } = useConsent()
   const [show, setShow] = useState(true)
+  const cookiesPolicyLink = useRef()
   const i18n = I18N[language]
 
   const handleCookiePolicyLayerClick = useCallback(() => {
@@ -28,9 +36,8 @@ export default function TcfFirstLayer({
         'click',
         handleCookiePolicyLayerClick
       )
-    openCookiepolicyLayer()
+    onOpenCookiePolicyLayer()
   })
-  const cookiesPolicyLink = useRef()
   const ref = useRef(null)
   const textRef = useCallback(
     node => {
@@ -68,21 +75,39 @@ export default function TcfFirstLayer({
   }, [])
 
   const handleSettingsClick = () => {
-    openSecondLayer()
+    onOpenSecondLayer()
   }
 
   const handleSaveExitClick = async () => {
-    const {purpose, vendor, specialFeatures} = await loadUserConsent()
+    const userConsent = await loadUserConsent()
+    const vendorList = await getVendorList()
+    const scope = await getScope()
+    scope.purposes = scope.purposes || Object.keys(vendorList.purposes)
+    scope.purposes.forEach(key => {
+      userConsent.purpose.consents[key] = true
+      userConsent.purpose.legitimateInterests[key] = true
+    })
+
+    scope.specialFeatures =
+      scope.specialFeatures || Object.keys(vendorList.specialFeatures)
+    scope.specialFeatures.forEach(
+      key => (userConsent.specialFeatures[key] = true)
+    )
+
+    Object.keys(vendorList.vendors).forEach(key => {
+      userConsent.vendor.consents[key] = true
+      userConsent.vendor.legitimateInterests[key] = true
+    })
     updateUserConsent({
-      purpose,
-      vendor,
-      specialFeatures,
+      purpose: userConsent.purpose,
+      vendor: userConsent.vendor,
+      specialFeatures: userConsent.specialFeatures,
       allPurposes: true,
       allVendors: true,
       allSpecialFeatures: true
     })
     handleCloseModal()
-    saveUserConsent()
+    onSaveUserConsent()
   }
 
   const handleCloseModal = () => {
@@ -117,7 +142,7 @@ export default function TcfFirstLayer({
           closeOnOutsideClick
           closeOnEscKeyDown
           header={<img className={`${CLASS}-logo`} src={logo} alt="logo" />}
-          iconClose={<IconClose class={`${CLASS}-icon-close`} />}
+          iconClose={<IconClose />}
           onClose={handleSaveExitClick}
           fitContent
           portalContainerId="sui-TcfFirstLayerModal"
@@ -144,10 +169,9 @@ export default function TcfFirstLayer({
 
 TcfFirstLayer.displayName = 'TcfFirstLayer'
 TcfFirstLayer.propTypes = {
-  openSecondLayer: PropTypes.func,
-  openCookiepolicyLayer: PropTypes.func,
-  loadUserConsent: PropTypes.func,
-  saveUserConsent: PropTypes.func,
+  onOpenSecondLayer: PropTypes.func,
+  onOpenCookiePolicyLayer: PropTypes.func,
+  onSaveUserConsent: PropTypes.func,
   logo: PropTypes.string,
   showInModalForMobile: PropTypes.bool
 }

--- a/components/tcf/ui/src/SecondLayer/index.js
+++ b/components/tcf/ui/src/SecondLayer/index.js
@@ -81,7 +81,12 @@ export default function TcfSecondLayer({
         prevState[group].consents[key] = value
         prevState[group].legitimateInterests[key] = value
       }
-      const nextState = {...prevState, [group]: prevState[group]}
+      const {vendors} = prevState
+      Object.keys(vendorListState.vendors).forEach(key => {
+        vendors.consents[key] = value
+        vendors.legitimateInterests[key] = value
+      })
+      const nextState = {...prevState, vendors, [group]: prevState[group]}
       saveConsentState(nextState)
       return nextState
     })
@@ -115,12 +120,25 @@ export default function TcfSecondLayer({
 
   const handleConsentsChange = ({group, index, value}) => {
     setState(prevState => {
+      const newValue = !value
       const {consents, legitimateInterests} = prevState[group]
       if (consents && legitimateInterests) {
-        consents[index] = !value
-        legitimateInterests[index] = !value
+        consents[index] = newValue
+        legitimateInterests[index] = newValue
+        const {vendors} = prevState
+        Object.entries(vendorListState.vendors).forEach(
+          ([key, vendorFromVendorList]) => {
+            if (vendorFromVendorList.purposes.includes(index)) {
+              vendors.consents[key] = newValue
+            }
+            if (vendorFromVendorList.legIntPurposes.includes(key)) {
+              vendors.legitimateInterests[key] = newValue
+            }
+          }
+        )
         const nextState = {
           ...prevState,
+          vendors,
           [group]: {...prevState[group], consents, legitimateInterests}
         }
         saveConsentState(nextState)
@@ -128,7 +146,7 @@ export default function TcfSecondLayer({
       } else {
         const nextState = {
           ...prevState,
-          [group]: {...prevState[group], [index]: !value}
+          [group]: {...prevState[group], [index]: newValue}
         }
         saveConsentState(nextState)
         return nextState

--- a/components/tcf/ui/src/SecondLayer/index.js
+++ b/components/tcf/ui/src/SecondLayer/index.js
@@ -121,21 +121,24 @@ export default function TcfSecondLayer({
   const handleConsentsChange = ({group, index, value}) => {
     setState(prevState => {
       const newValue = !value
+      const isPurposesGroup = group === 'purposes'
       const {consents, legitimateInterests} = prevState[group]
       if (consents && legitimateInterests) {
         consents[index] = newValue
         legitimateInterests[index] = newValue
         const {vendors} = prevState
-        Object.entries(vendorListState.vendors).forEach(
-          ([key, vendorFromVendorList]) => {
-            if (vendorFromVendorList.purposes.includes(index)) {
-              vendors.consents[key] = newValue
+        if (isPurposesGroup) {
+          Object.entries(vendorListState.vendors).forEach(
+            ([key, vendorFromVendorList]) => {
+              if (vendorFromVendorList.purposes.includes(index)) {
+                vendors.consents[key] = newValue
+              }
+              if (vendorFromVendorList.legIntPurposes.includes(index)) {
+                vendors.legitimateInterests[key] = newValue
+              }
             }
-            if (vendorFromVendorList.legIntPurposes.includes(index)) {
-              vendors.legitimateInterests[key] = newValue
-            }
-          }
-        )
+          )
+        }
         const nextState = {
           ...prevState,
           vendors,

--- a/components/tcf/ui/src/SecondLayer/index.js
+++ b/components/tcf/ui/src/SecondLayer/index.js
@@ -16,7 +16,7 @@ const groupBaseClass = `${CLASS}-group`
 
 export default function TcfSecondLayer({
   logo,
-  saveUserConsent,
+  onSaveUserConsent,
   onGoBack,
   onVendorsClick,
   isVendorLayer
@@ -68,7 +68,7 @@ export default function TcfSecondLayer({
   }
 
   const handleSaveExitClick = () => {
-    saveUserConsent()
+    onSaveUserConsent()
     handleCloseModal()
   }
 
@@ -291,9 +291,7 @@ export default function TcfSecondLayer({
 TcfSecondLayer.displayName = 'TcfSecondLayer'
 TcfSecondLayer.propTypes = {
   isVendorLayer: PropTypes.bool,
-  loadUserConsent: PropTypes.func,
-  saveUserConsent: PropTypes.func,
-  getVendorList: PropTypes.func,
+  onSaveUserConsent: PropTypes.func,
   logo: PropTypes.string,
   onGoBack: PropTypes.func,
   onVendorsClick: PropTypes.func

--- a/components/tcf/ui/src/SecondLayer/index.js
+++ b/components/tcf/ui/src/SecondLayer/index.js
@@ -131,7 +131,7 @@ export default function TcfSecondLayer({
             if (vendorFromVendorList.purposes.includes(index)) {
               vendors.consents[key] = newValue
             }
-            if (vendorFromVendorList.legIntPurposes.includes(key)) {
+            if (vendorFromVendorList.legIntPurposes.includes(index)) {
               vendors.legitimateInterests[key] = newValue
             }
           }

--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -52,7 +52,7 @@ export default function TCFContainer({
   const handleThirdLayerGoBack = () => {
     setShowLayer(2)
   }
-  const handleOpenCookiepolicyLayer = () => {
+  const handleOpenCookiePolicyLayer = () => {
     setShowLayer(3)
   }
   const handleSaveUserConsent = async () => {
@@ -68,9 +68,9 @@ export default function TCFContainer({
         <Suspense fallback={<div />}>
           <FirstLayer
             logo={logo}
-            saveUserConsent={handleSaveUserConsent}
-            openSecondLayer={handleOpenSecondLayer}
-            openCookiepolicyLayer={handleOpenCookiepolicyLayer}
+            onSaveUserConsent={handleSaveUserConsent}
+            onOpenSecondLayer={handleOpenSecondLayer}
+            onOpenCookiePolicyLayer={handleOpenCookiePolicyLayer}
             showInModalForMobile={showInModalForMobile}
           />
         </Suspense>
@@ -79,7 +79,7 @@ export default function TCFContainer({
         <Suspense fallback={<div />}>
           <SecondLayer
             logo={logo}
-            saveUserConsent={handleSaveUserConsent}
+            onSaveUserConsent={handleSaveUserConsent}
             onGoBack={handleSecondLayerGoBack}
             onVendorsClick={handleVendorsClick}
           />
@@ -90,7 +90,7 @@ export default function TCFContainer({
           <SecondLayer
             isVendorLayer
             logo={logo}
-            saveUserConsent={handleSaveUserConsent}
+            onSaveUserConsent={handleSaveUserConsent}
             onGoBack={handleThirdLayerGoBack}
           />
         </Suspense>


### PR DESCRIPTION
## GOAL
This PR resolves this behavior:

### All accepted
- If new user click on "Seguir navegando" in first layer. All purposes, vendors, ... will be accepted
<img width="623" alt="acepto-firstLayer" src="https://user-images.githubusercontent.com/45286922/89205159-8d9f9a00-d5b7-11ea-8886-e55ab678acb4.png">

Consent String: 

```CO3kkl9O3kkl9CBAGAENAxCoAP_AAH_AAAiQGPtX_T9fb2vj-_Z99_tkeY1f97y3t-wzhheMs-8NyZeX_B4Wv2MyvBX4JiQKGRgkunLBAQdtHGlcTQgBwIlViTLMYk2MjzNKJrJEmlsbe2dYGH9vn8XT_ZKZ70-vv__7v3_f_334GPtX_T9fb2vj-_Z99_tkeY1f97y3t-wzhheMs-8NyZeX_B4Wv2MyvBX4JiQKGRgkunLBAQdtHGlcTQgBwIlViTLMYk2MjzNKJrJEmlsbe2dYGH9vn8XT_ZKZ70-vv__7v3_f_334AAAA.YAAAAAAAAAAA```

### No consent at all
- if new user clicks on "Configurar", second layer will appear with all purposes, vendors,... disabled. If user accepts that the consent will be this (no consents, all vendors: with legitimateInterest true, consents false):
<img width="629" alt="Screenshot 2020-08-04 at 09 47 53" src="https://user-images.githubusercontent.com/45286922/89267706-deef6e00-d637-11ea-8f0e-da862d0b6166.png">


Consent string:

```CO3mrlZO3mrlZCBAGAENAxCgAAAAAAAAAAiQAAAMfav-n6-3tfH9-z77_bI8xq_73lvb9hnDC8ZZ94bky8v-DwtfsZleCvwTEgUMjBJdOWCAg7aONK4mhADgRKrEmWYxJsZHmaUTWSJNLY29s6wMP7fP4un-yUz3p9ff__3fv-__vvwAAAAA.YAAAAAAAAAAA```

### One purpose accepted
- If new user clicks on "Configurar",  second layer will appear with all purposes, vendors,... disabled. If one or more purposes was accepted the purposes goes to true, and vendors with this purpose will be true, all vendor.legitimateInterest will be true

In this example (purpose 7):
<img width="784" alt="purpose-7-enabled" src="https://user-images.githubusercontent.com/45286922/89205750-7dd48580-d5b8-11ea-9730-9bf16a1093ef.png">

<img width="631" alt="Screenshot 2020-08-04 at 09 50 59" src="https://user-images.githubusercontent.com/45286922/89267872-1231fd00-d638-11ea-930b-b0963a79106f.png">

Consent string:

```CO3msDyO3msDyCBAGAENAxCgAAEAAAEAAAiQGPICKBEAQEAAAgAggBIAIAAGAKigFIQhBgAAMKQEQACTAAIEAgEglARAJgACGBAAGEAAAABkGCAAAQAAAAkBgALEQACMAyBABpAAAgEaEgIICARpEkFAOIAYTkCoEKjQHmKBcGEQMfav-n6-3tfH9-z77_bI8xq_73lvb9hnDC8ZZ94bky8v-DwtfsZleCvwTEgUMjBJdOWCAg7aONK4mhADgRKrEmWYxJsZHmaUTWSJNLY29s6wMP7fP4un-yUz3p9ff__3fv-__vvwAAAA.YAAAAAAAAAAA```

## Solves ticket
https://jira.scmspain.com/browse/PSP-3448

## Review steps
For not devs: You can review the consents above in http://iabtcf.com/#/
For devs: You can up the demo of tcf/ui linking tcf/service in sui-studio

## Further considerations
Some minor refactor of the name in props of onSaveUserConsent, onOpenSecondLayer, ... was changed for clarity in code