### PR TITLE
allow to select and deselect consent and legitimate interest in vendors

### DIFF
--- a/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-decision-group/index.js
+++ b/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-decision-group/index.js
@@ -39,10 +39,14 @@ export function TcfSecondLayerDecisionGroup({
   }
   const ButtonAll = React.memo(() => (
     <div className={`${baseClass}Header-buttons`}>
-      <Button size="small" design="outline" onClick={onRejectAll}>
+      <Button
+        size="small"
+        design="outline"
+        onClick={() => onRejectAll({decisionKey})}
+      >
         {i18n.DISABLE_BUTTON}
       </Button>
-      <Button size="small" onClick={onAcceptAll}>
+      <Button size="small" onClick={() => onAcceptAll({decisionKey})}>
         {i18n.ENABLE_BUTTON}
       </Button>
     </div>
@@ -82,7 +86,9 @@ export function TcfSecondLayerDecisionGroup({
             consentValue={consentValue}
             hasConsent={hasConsent}
             i18n={i18n}
-            onConsentChange={value => onConsentChange({index: key, value})}
+            onConsentChange={value =>
+              onConsentChange({index: key, value, decisionKey})
+            }
             expandedContent={expandedContent}
           />
         )

--- a/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-decision-group/index.js
+++ b/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-decision-group/index.js
@@ -6,19 +6,20 @@ import Button from '@s-ui/react-atom-button'
 import TcfSecondLayerUserDecision from '../tcf-secondLayer-user-decision'
 import TcfSecondLayerVendorsUserDecision from '../tcf-secondLayer-vendors-user-decision'
 export function TcfSecondLayerDecisionGroup({
-  name,
-  i18n,
   baseClass,
+  decisionKey = 'consents',
   descriptions,
-  state,
+  expandedContent,
   filteredIds,
   hasConsent,
-  onConsentChange,
+  i18n,
+  isVendorLayer,
+  name,
   onAcceptAll,
+  onConsentChange,
   onRejectAll,
-  vendorList,
-  expandedContent,
-  isVendorLayer
+  state,
+  vendorList
 }) {
   const [descriptionKeys, setDescriptionKeys] = useState(null)
   useEffect(() => {
@@ -56,8 +57,8 @@ export function TcfSecondLayerDecisionGroup({
       {/* sui-TcfSecondLayer-group-item- */}
       {/* sui-TcfSecondLayer-group-item--vendors */}
       {descriptionKeys.map((key, index) => {
-        const consentValue = state?.consents
-          ? state.consents[key]
+        const consentValue = state?.[decisionKey]
+          ? state[decisionKey][key]
           : state?.[key]
         return isVendorLayer ? (
           <TcfSecondLayerUserDecision
@@ -68,7 +69,9 @@ export function TcfSecondLayerDecisionGroup({
             hasConsent={hasConsent}
             i18n={i18n}
             vendorList={vendorList}
-            onConsentChange={value => onConsentChange({index: key, value})}
+            onConsentChange={value =>
+              onConsentChange({index: key, value, decisionKey})
+            }
             expandedContent={expandedContent}
           />
         ) : (
@@ -79,7 +82,6 @@ export function TcfSecondLayerDecisionGroup({
             consentValue={consentValue}
             hasConsent={hasConsent}
             i18n={i18n}
-            vendorList={vendorList}
             onConsentChange={value => onConsentChange({index: key, value})}
             expandedContent={expandedContent}
           />
@@ -89,20 +91,25 @@ export function TcfSecondLayerDecisionGroup({
   )
 }
 
+TcfSecondLayerDecisionGroup.defaultProps = {
+  decisionKey: 'consents'
+}
+
 TcfSecondLayerDecisionGroup.propTypes = {
-  name: PropTypes.string,
-  i18n: PropTypes.object,
   baseClass: PropTypes.string,
+  decisionKey: PropTypes.string,
   descriptions: PropTypes.object,
-  state: PropTypes.object,
+  expandedContent: PropTypes.func,
   filteredIds: PropTypes.func,
   hasConsent: PropTypes.bool,
+  i18n: PropTypes.object,
   isVendorLayer: PropTypes.bool,
-  onConsentChange: PropTypes.func,
+  name: PropTypes.string,
   onAcceptAll: PropTypes.func,
+  onConsentChange: PropTypes.func,
   onRejectAll: PropTypes.func,
-  vendorList: PropTypes.object,
-  expandedContent: PropTypes.func
+  state: PropTypes.object,
+  vendorList: PropTypes.object
 }
 
 export default React.memo(TcfSecondLayerDecisionGroup)

--- a/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-vendorList/index.js
+++ b/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-vendorList/index.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import TcfSecondLayerDecisionGroup from '../tcf-secondLayer-decision-group'
+export default function TcfSecondLayerVendorList({
+  i18n,
+  groupBaseClass,
+  vendorListState,
+  state,
+  handleConsentsChange,
+  handleAcceptAll,
+  handleRejectAll,
+  vendorExpandedContent
+}) {
+  return (
+    <TcfSecondLayerDecisionGroup
+      name={i18n.VENDOR_PAGE.GROUPS.TITLE}
+      baseClass={groupBaseClass}
+      descriptions={vendorListState.vendors}
+      state={state.vendors}
+      onConsentChange={props =>
+        handleConsentsChange({group: 'vendors', ...props})
+      }
+      hasConsent
+      i18n={i18n}
+      onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
+      onRejectAll={() => handleRejectAll({group: 'vendors'})}
+      vendorList={vendorListState}
+      expandedContent={vendorExpandedContent}
+      isVendorLayer
+    />
+  )
+}
+
+TcfSecondLayerVendorList.propTypes = {
+  i18n: PropTypes.object,
+  groupBaseClass: PropTypes.string,
+  vendorListState: PropTypes.object,
+  state: PropTypes.object,
+  handleConsentsChange: PropTypes.func,
+  handleAcceptAll: PropTypes.func,
+  handleRejectAll: PropTypes.func,
+  vendorExpandedContent: PropTypes.object
+}

--- a/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-vendorList/index.js
+++ b/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-vendorList/index.js
@@ -34,11 +34,19 @@ export default function TcfSecondLayerVendorList({
         i18n={i18n}
         isVendorLayer
         name={i18n.VENDOR_PAGE.GROUPS.TITLE_CONSENT}
-        onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
-        onConsentChange={props =>
-          handleConsentsChange({group: 'vendors', ...props})
+        onAcceptAll={props =>
+          handleAcceptAll({group: 'vendors', decisionKey: 'consents', ...props})
         }
-        onRejectAll={() => handleRejectAll({group: 'vendors'})}
+        onConsentChange={props =>
+          handleConsentsChange({
+            group: 'vendors',
+            decisionKey: 'consents',
+            ...props
+          })
+        }
+        onRejectAll={props =>
+          handleRejectAll({group: 'vendors', decisionKey: 'consents', ...props})
+        }
         state={state.vendors}
         vendorList={vendorListState}
       />
@@ -51,11 +59,27 @@ export default function TcfSecondLayerVendorList({
         i18n={i18n}
         isVendorLayer
         name={i18n.VENDOR_PAGE.GROUPS.TITLE_LEGITIMATEINTEREST}
-        onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
-        onConsentChange={props =>
-          handleConsentsChange({group: 'vendors', ...props})
+        onAcceptAll={props =>
+          handleAcceptAll({
+            group: 'vendors',
+            decisionKey: 'legitimateInterests',
+            ...props
+          })
         }
-        onRejectAll={() => handleRejectAll({group: 'vendors'})}
+        onConsentChange={props =>
+          handleConsentsChange({
+            group: 'vendors',
+            decisionKey: 'legitimateInterests',
+            ...props
+          })
+        }
+        onRejectAll={props =>
+          handleRejectAll({
+            group: 'vendors',
+            decisionKey: 'legitimateInterests',
+            ...props
+          })
+        }
         state={state.vendors}
         vendorList={vendorListState}
       />

--- a/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-vendorList/index.js
+++ b/components/tcf/ui/src/SecondLayer/components/tcf-secondLayer-vendorList/index.js
@@ -11,33 +11,65 @@ export default function TcfSecondLayerVendorList({
   handleRejectAll,
   vendorExpandedContent
 }) {
+  const {vendors} = vendorListState
+  const consentVendors = {}
+  const legitimateInterestVendors = {}
+  for (const key in vendors) {
+    if (vendors[key].purposes.length) {
+      consentVendors[key] = vendors[key]
+    }
+    if (vendors[key].legIntPurposes.length) {
+      legitimateInterestVendors[key] = vendors[key]
+    }
+  }
   return (
-    <TcfSecondLayerDecisionGroup
-      name={i18n.VENDOR_PAGE.GROUPS.TITLE}
-      baseClass={groupBaseClass}
-      descriptions={vendorListState.vendors}
-      state={state.vendors}
-      onConsentChange={props =>
-        handleConsentsChange({group: 'vendors', ...props})
-      }
-      hasConsent
-      i18n={i18n}
-      onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
-      onRejectAll={() => handleRejectAll({group: 'vendors'})}
-      vendorList={vendorListState}
-      expandedContent={vendorExpandedContent}
-      isVendorLayer
-    />
+    <>
+      <h2>{i18n.VENDOR_PAGE.GROUPS.TITLE}</h2>
+      <TcfSecondLayerDecisionGroup
+        baseClass={groupBaseClass}
+        decisionKey="consents"
+        descriptions={consentVendors}
+        expandedContent={vendorExpandedContent}
+        hasConsent
+        i18n={i18n}
+        isVendorLayer
+        name={i18n.VENDOR_PAGE.GROUPS.TITLE_CONSENT}
+        onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
+        onConsentChange={props =>
+          handleConsentsChange({group: 'vendors', ...props})
+        }
+        onRejectAll={() => handleRejectAll({group: 'vendors'})}
+        state={state.vendors}
+        vendorList={vendorListState}
+      />
+      <TcfSecondLayerDecisionGroup
+        baseClass={groupBaseClass}
+        decisionKey="legitimateInterests"
+        descriptions={legitimateInterestVendors}
+        expandedContent={vendorExpandedContent}
+        hasConsent
+        i18n={i18n}
+        isVendorLayer
+        name={i18n.VENDOR_PAGE.GROUPS.TITLE_LEGITIMATEINTEREST}
+        onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
+        onConsentChange={props =>
+          handleConsentsChange({group: 'vendors', ...props})
+        }
+        onRejectAll={() => handleRejectAll({group: 'vendors'})}
+        state={state.vendors}
+        vendorList={vendorListState}
+      />
+    </>
   )
 }
 
 TcfSecondLayerVendorList.propTypes = {
-  i18n: PropTypes.object,
   groupBaseClass: PropTypes.string,
-  vendorListState: PropTypes.object,
-  state: PropTypes.object,
-  handleConsentsChange: PropTypes.func,
   handleAcceptAll: PropTypes.func,
+  handleConsentsChange: PropTypes.func,
   handleRejectAll: PropTypes.func,
-  vendorExpandedContent: PropTypes.object
+  i18n: PropTypes.object,
+  state: PropTypes.object,
+  vendorExpandedContent: PropTypes.object,
+  vendorListState: PropTypes.object
 }

--- a/components/tcf/ui/src/SecondLayer/index.js
+++ b/components/tcf/ui/src/SecondLayer/index.js
@@ -76,27 +76,33 @@ export default function TcfSecondLayer({
   const saveConsentState = ({purposes, vendors, specialFeatures}) =>
     updateUserConsent({purpose: purposes, vendor: vendors, specialFeatures})
 
-  const changeAllGroup = ({group, value}) => {
+  const changeAllGroup = ({group, decisionKey, value}) => {
     setState(prevState => {
-      for (const key in vendorListState[group]) {
-        prevState[group].consents[key] = value
-        prevState[group].legitimateInterests[key] = value
+      if (group !== 'vendors') {
+        for (const key in vendorListState[group]) {
+          prevState[group].consents[key] = value
+          prevState[group].legitimateInterests[key] = value
+        }
       }
       const {vendors} = prevState
       Object.keys(vendorListState.vendors).forEach(key => {
-        vendors.consents[key] = value
-        vendors.legitimateInterests[key] = value
+        if (!decisionKey) {
+          vendors.consents[key] = value
+          vendors.legitimateInterests[key] = value
+        } else {
+          vendors[decisionKey][key] = value
+        }
       })
       const nextState = {...prevState, vendors, [group]: prevState[group]}
       saveConsentState(nextState)
       return nextState
     })
   }
-  const handleRejectAll = ({group}) => {
-    changeAllGroup({group, value: false})
+  const handleRejectAll = props => {
+    changeAllGroup({...props, value: false})
   }
-  const handleAcceptAll = ({group}) => {
-    changeAllGroup({group, value: true})
+  const handleAcceptAll = props => {
+    changeAllGroup({...props, value: true})
   }
 
   const handleAcceptAllSpecialFeatures = async () => {
@@ -119,16 +125,16 @@ export default function TcfSecondLayer({
     setState(nextState)
   }
 
-  const handleConsentsChange = ({group, index, value}) => {
+  const handleConsentsChange = ({group, decisionKey, index, value}) => {
     setState(prevState => {
       const newValue = !value
-      const isPurposesGroup = group === 'purposes'
+      let nextState = {...prevState}
       const {consents, legitimateInterests} = prevState[group]
-      if (consents && legitimateInterests) {
-        consents[index] = newValue
-        legitimateInterests[index] = newValue
-        const {vendors} = prevState
-        if (isPurposesGroup) {
+      const {vendors} = prevState
+      switch (group) {
+        case 'purposes':
+          consents[index] = newValue
+          legitimateInterests[index] = newValue
           Object.entries(vendorListState.vendors).forEach(
             ([key, vendorFromVendorList]) => {
               if (vendorFromVendorList.purposes.includes(index)) {
@@ -139,22 +145,28 @@ export default function TcfSecondLayer({
               }
             }
           )
-        }
-        const nextState = {
-          ...prevState,
-          vendors,
-          [group]: {...prevState[group], consents, legitimateInterests}
-        }
-        saveConsentState(nextState)
-        return nextState
-      } else {
-        const nextState = {
-          ...prevState,
-          [group]: {...prevState[group], [index]: newValue}
-        }
-        saveConsentState(nextState)
-        return nextState
+          nextState = {
+            ...prevState,
+            purposes: {...prevState.purposes, consents, legitimateInterests},
+            vendors
+          }
+          break
+        case 'vendors':
+          vendors[decisionKey][index] = newValue
+          nextState = {
+            ...prevState,
+            vendors
+          }
+          break
+        case 'specialFeatures':
+          nextState = {
+            ...prevState,
+            specialFeatures: {...prevState.specialFeatures, [index]: newValue}
+          }
+          break
       }
+      saveConsentState(nextState)
+      return nextState
     })
   }
 

--- a/components/tcf/ui/src/SecondLayer/index.js
+++ b/components/tcf/ui/src/SecondLayer/index.js
@@ -10,6 +10,7 @@ import TcfSecondLayerVendorExpandedContent from './components/tcf-secondLayer-ve
 
 import {I18N} from './settings'
 import TcfSecondLayerLegalExpandedContent from './components/tcf-secondLayer-legal-expandedContent'
+import TcfSecondLayerVendorList from './components/tcf-secondLayer-vendorList'
 
 const CLASS = 'sui-TcfSecondLayer'
 const groupBaseClass = `${CLASS}-group`
@@ -263,21 +264,15 @@ export default function TcfSecondLayer({
             />
           )}
           {!!state?.vendors && !!vendorListState?.vendors && isVendorLayer && (
-            <TcfSecondLayerDecisionGroup
-              name={i18n.VENDOR_PAGE.GROUPS.TITLE}
-              baseClass={groupBaseClass}
-              descriptions={vendorListState.vendors}
-              state={state.vendors}
-              onConsentChange={props =>
-                handleConsentsChange({group: 'vendors', ...props})
-              }
-              hasConsent
+            <TcfSecondLayerVendorList
               i18n={i18n}
-              onAcceptAll={() => handleAcceptAll({group: 'vendors'})}
-              onRejectAll={() => handleRejectAll({group: 'vendors'})}
-              vendorList={vendorListState}
-              expandedContent={vendorExpandedContent}
-              isVendorLayer={isVendorLayer}
+              groupBaseClass={groupBaseClass}
+              vendorListState={vendorListState}
+              state={state}
+              handleConsentsChange={handleConsentsChange}
+              handleAcceptAll={handleAcceptAll}
+              handleRejectAll={handleRejectAll}
+              vendorExpandedContent={vendorExpandedContent}
             />
           )}
         </div>

--- a/components/tcf/ui/src/SecondLayer/settings.js
+++ b/components/tcf/ui/src/SecondLayer/settings.js
@@ -23,6 +23,8 @@ const DEFAULT_I18N = {
       'Nos importa mucho tu privacidad, por esta razón queremos informarte de las finalidades perseguidas por las cookies de publicidad personalizada además de con quién estamos compartiendo tus datos. Asimismo podrás definir las finalidades y los terceros con los que aceptas o no compartir tus datos de navegación, tus datos de localización y tus datos de carácter personal. Ten en cuenta que estas cookies van ligadas a tu sesión en el navegador por lo que si actualizas tus cookies, cambias de dispositivos o te conectas desde otro navegador, tendrás que volver a configurar tus preferencias.',
     GROUPS: {
       TITLE: 'Listado de partners con los que trabajamos',
+      TITLE_CONSENT: 'Con base en el consentimiento de usuario',
+      TITLE_LEGITIMATEINTEREST: 'Con base en el legítimo interés',
       EXPANDED: {
         PURPOSES: 'Propósitos',
         LEGITIMATE_INTEREST_PURPOSES: 'Interés legítimo en:',

--- a/components/tcf/ui/src/SecondLayer/settings.js
+++ b/components/tcf/ui/src/SecondLayer/settings.js
@@ -23,8 +23,9 @@ const DEFAULT_I18N = {
       'Nos importa mucho tu privacidad, por esta razón queremos informarte de las finalidades perseguidas por las cookies de publicidad personalizada además de con quién estamos compartiendo tus datos. Asimismo podrás definir las finalidades y los terceros con los que aceptas o no compartir tus datos de navegación, tus datos de localización y tus datos de carácter personal. Ten en cuenta que estas cookies van ligadas a tu sesión en el navegador por lo que si actualizas tus cookies, cambias de dispositivos o te conectas desde otro navegador, tendrás que volver a configurar tus preferencias.',
     GROUPS: {
       TITLE: 'Listado de partners con los que trabajamos',
-      TITLE_CONSENT: 'Con base en el consentimiento de usuario',
-      TITLE_LEGITIMATEINTEREST: 'Con base en el legítimo interés',
+      TITLE_CONSENT: 'Tratamiento de datos basado en consentimiento',
+      TITLE_LEGITIMATEINTEREST:
+        'Tratamiento de datos basado en interés legítimo',
       EXPANDED: {
         PURPOSES: 'Propósitos',
         LEGITIMATE_INTEREST_PURPOSES: 'Interés legítimo en:',
@@ -58,6 +59,9 @@ const IT_I18N = {
   },
   VENDOR_PAGE: {
     TITLE: 'Cookie di prima o terza parte per la pubblicità segmentata',
+    TITLE_CONSENT: 'Trattamento dei dati basato sul consenso',
+    TITLE_LEGITIMATEINTEREST:
+      "Trattamento dei dati basato sull'interesse legittimo",
     TEXT:
       'Ci preoccupiamo molto della tua privacy, per questo motivo vogliamo informarti delle finalità perseguite dai cookie per la pubblicità personalizzata, e farti sapere con chi stiamo condividendo le tue informazioni. Potrai inoltre definire le finalità e le terze parti con le quali accetti o meno di condividere i tuoi dati di navigazione, di posizione e i tuoi dati personali. Tieni presente che questi cookie sono legati alla tua sessione di navigazione, quindi se aggiorni i tuoi cookie, cambiando dispositivo o connettendoti da un altro browser, dovrai riconfigurare le tue preferenze.',
     GROUPS: {


### PR DESCRIPTION
## GOAL

Allows users to select and deselect consent and legitimate interest separately.

<img width="815" alt="Screenshot 2020-08-04 at 13 07 01" src="https://user-images.githubusercontent.com/45286922/89287007-731afe80-d653-11ea-85c2-b660c8ce0ea5.png">

<img width="830" alt="Screenshot 2020-08-04 at 13 07 49" src="https://user-images.githubusercontent.com/45286922/89287064-8c23af80-d653-11ea-8943-853ef12e7c1a.png">


## Examples

### Example 1 - Select 2 consents:
If new user, clicks on "Configurar", all purposes are disabled, and select consent of 2 first vendors (by default, all(458) legitimate interest are enabled below)

<img width="797" alt="Screenshot 2020-08-04 at 12 57 43" src="https://user-images.githubusercontent.com/45286922/89286240-1ff47c00-d652-11ea-8adb-dc9d72bc374b.png">

will produce this consent string ```CO3nHsiO3nHsiCBAGAENAxCgAAAAAAAAAAiQABMDH2r_p-vt7Xx_fs--_2yPMav-95b2_YZwwvGWfeG5MvL_g8LX7GZXgr8ExIFDIwSXTlggIO2jjSuJoQA4ESqxJlmMSbGR5mlE1kiTS2NvbOsDD-3z-Lp_slM96fX3__937_v_778AAAAA.YAAAAAAAAAAA```

<img width="623" alt="Screenshot 2020-08-04 at 12 59 36" src="https://user-images.githubusercontent.com/45286922/89286432-7b266e80-d652-11ea-8510-476f7b5cc4f2.png">

### Example 2 - Deselect 2 legitimate interest:
If new user, clicks on "Configurar", all purposes are disabled and deselect legitimate interest of 2 first vendors (by default, all consents are disabled and all(458) legitimate interest are enabled)

<img width="844" alt="Screenshot 2020-08-04 at 13 02 53" src="https://user-images.githubusercontent.com/45286922/89286696-f556f300-d652-11ea-950e-ffee290d2726.png">

will produce this consent string  ```CO3nIbGO3nIbGCBAGAENAxCgAAAAAAAAAAiQAAAMfSn-n6-3tfH9-z77_bI8xq_73lvb9hnDC8ZZ94bky8v-DwtfsZleCvwTEgUMjBJdOWCAg7aONK4mhADgRKrEmWYxJsZHmaUTWSJNLY29s6wMP7fP4un-yUz3p9ff__3fv-__vvwAAAAA.YAAAAAAAAAAA```

<img width="631" alt="Screenshot 2020-08-04 at 13 04 30" src="https://user-images.githubusercontent.com/45286922/89286846-30592680-d653-11ea-99ab-98b1d35db24e.png">
