### PR TITLE
fix(script/jsonLD): use dangerouslySetInnerHTML for avoid issues on b…

### DIFF
--- a/components/script/jsonLD/src/index.js
+++ b/components/script/jsonLD/src/index.js
@@ -5,7 +5,10 @@ function ScriptJsonLD({json}) {
   return (
     <>
       {json && (
-        <script type="application/ld+json">{JSON.stringify(json)}</script>
+        <script
+          dangerouslySetInnerHTML={{__html: JSON.stringify(json)}}
+          type="application/ld+json"
+        />
       )}
     </>
   )


### PR DESCRIPTION
Without `dangerouslySetInnerHTML` we detected that sui-bundler build it and replace spaces by html entities and Google Validation tool don't like it