### PR TITLE
feat(tcf/ui): modify the TCF to remove styles only from infojobs

### DIFF
--- a/components/tcf/ui/src/FirstLayer/index.scss
+++ b/components/tcf/ui/src/FirstLayer/index.scss
@@ -91,9 +91,6 @@ $base-class-modal: '#sui-TcfFirstLayerModal';
   .sui-MoleculeNotification {
     background-color: $c-white;
     box-shadow: $bxsh-tcf-first-layer;
-    &-content {
-      background-color: $c-white;
-    }
   }
 }
 

--- a/components/tcf/ui/src/SecondLayer/index.scss
+++ b/components/tcf/ui/src/SecondLayer/index.scss
@@ -47,7 +47,6 @@ $base-class-modal: '#sui-TcfSecondLayerModal';
   .sui-MoleculeModal-header {
     padding: $p-l 0 $p-l $ml-tcf-second-layer-modal-mobile;
     border-bottom: $bdw-s solid $c-gray-light-3;
-    background-color: $c-white;
     @include media-breakpoint-up(s) {
       padding: $p-xxl 0 $p-xxl $ml-tcf-second-layer-modal;
     }


### PR DESCRIPTION
## Description
Modify the TCF to remove styles only from Infojobs

## Solves ticket/s
https://jira.scmspain.com/browse/PSP-3471

## Expected behavior
Background color change should be applied only for Infojobs

## Further considerations
The changes will be applied to the React component of Infojobs:
https://github.mpi-internal.com/scmspain/frontend-jobs--uilib-components/blob/14fa006f15702bf1bf5dcabb9a9450c235cfa032/components/ads/cmpUi/src/index.scss
