### PR TITLE
feat(form/builder): add numeric money field input rightAddon € icon

### DIFF
--- a/components/form/builder/src/Standard/Fields/Numeric/index.js
+++ b/components/form/builder/src/Standard/Fields/Numeric/index.js
@@ -25,6 +25,7 @@ const NumericField = ({
         errors={errors}
         alerts={alerts}
         renderer={renderer}
+        rightAddon="€"
       />
     )
   } else {


### PR DESCRIPTION
Add right addon "€" icon to numeric money field input .