### PR TITLE
feat(image/slider): add imageObjectFit as prop for sliderOptions

### DIFF
--- a/components/image/slider/src/index.js
+++ b/components/image/slider/src/index.js
@@ -140,6 +140,7 @@ ImageSlider.propTypes = {
     classNameArrows: PropTypes.string,
     doAfterSlide: PropTypes.func,
     lazyLoadSlider: PropTypes.bool,
+    imageObjectFit: PropTypes.oneOf(['cover', 'contain']),
     initialSlide: PropTypes.number,
     numOfSlides: PropTypes.number
   }),


### PR DESCRIPTION
We're currently not dealing with `imageObjectFit` prop when passed within `sliderOptions` prop. This PR addresses that.