### PR TITLE
feature/tcf ui testing modal

### DIFF
--- a/components/tcf/ui/src/FirstLayer/index.js
+++ b/components/tcf/ui/src/FirstLayer/index.js
@@ -4,7 +4,7 @@ import {useConsent} from '@s-ui/react-tcf-services'
 import SuiButton from '@s-ui/react-atom-button'
 import SuiModal from '@s-ui/react-molecule-modal'
 import SuiNotification from '@s-ui/react-molecule-notification'
-// import IconClose from './iconClose'
+// import IconClose from './iconClose'  // Commented due testAB
 import {I18N} from './settings'
 
 const CLASS = 'sui-TcfFirstLayer'
@@ -70,7 +70,7 @@ export default function TcfFirstLayer({
     }
   }
   useEffect(() => {
-    if (!isTestAcceptedWithUserScroll) return // Temporary for testAB pursoses
+    if (!isTestAcceptedWithUserScroll) return // Temporary for testAB
     initialYOffset = window.pageYOffset
     document.addEventListener('scroll', checkScroll, {passive: true})
     return () => document.removeEventListener('scroll', checkScroll)
@@ -146,7 +146,7 @@ export default function TcfFirstLayer({
           closeOnOutsideClick={false}
           closeOnEscKeyDown={false}
           header={<img className={`${CLASS}-logo`} src={logo} alt="logo" />}
-          // iconClose={<IconClose />}  // Removed for testingAB
+          // iconClose={<IconClose />}  // Removed for testAB
           onClose={handleSaveExitClick}
           fitContent
           portalContainerId="sui-TcfFirstLayerModal"

--- a/components/tcf/ui/src/FirstLayer/index.js
+++ b/components/tcf/ui/src/FirstLayer/index.js
@@ -120,14 +120,12 @@ export default function TcfFirstLayer({
 
   const Content = () => {
     return (
-      <>
-        <div className={`${CLASS}-body`}>
-          <div
-            className={`${CLASS}-info`}
-            ref={textRef}
-            dangerouslySetInnerHTML={{__html: i18n.BODY}}
-          />
-        </div>
+      <div className={`${CLASS}-body`}>
+        <div
+          className={`${CLASS}-info`}
+          ref={textRef}
+          dangerouslySetInnerHTML={{__html: i18n.BODY}}
+        />
         <div className={`${CLASS}-buttons`}>
           <SuiButton onClick={handleSettingsClick} design="outline">
             {i18n.CONFIGURE_BUTTON}
@@ -136,7 +134,7 @@ export default function TcfFirstLayer({
             {i18n.CONTINUE_NAVIGATION_BUTTON}
           </SuiButton>
         </div>
-      </>
+      </div>
     )
   }
 

--- a/components/tcf/ui/src/FirstLayer/index.js
+++ b/components/tcf/ui/src/FirstLayer/index.js
@@ -4,7 +4,7 @@ import {useConsent} from '@s-ui/react-tcf-services'
 import SuiButton from '@s-ui/react-atom-button'
 import SuiModal from '@s-ui/react-molecule-modal'
 import SuiNotification from '@s-ui/react-molecule-notification'
-import IconClose from './iconClose'
+// import IconClose from './iconClose'
 import {I18N} from './settings'
 
 const CLASS = 'sui-TcfFirstLayer'
@@ -12,11 +12,12 @@ const CLASS = 'sui-TcfFirstLayer'
 const SCROLL_TO_ACCEPT = 250
 
 export default function TcfFirstLayer({
+  isTestAcceptedWithUserScroll = true,
+  isTestForceModal = false,
   logo,
-  onSaveUserConsent,
-  onOpenSecondLayer,
   onOpenCookiePolicyLayer,
-  showInModalForMobile = false
+  onOpenSecondLayer,
+  onSaveUserConsent
 }) {
   const {
     isMobile,
@@ -69,6 +70,7 @@ export default function TcfFirstLayer({
     }
   }
   useEffect(() => {
+    if (!isTestAcceptedWithUserScroll) return // Temporary for testAB pursoses
     initialYOffset = window.pageYOffset
     document.addEventListener('scroll', checkScroll, {passive: true})
     return () => document.removeEventListener('scroll', checkScroll)
@@ -138,13 +140,13 @@ export default function TcfFirstLayer({
 
   return (
     <div className={`${isMobile ? `${CLASS} ${CLASS}--isMobile` : `${CLASS}`}`}>
-      {isMobile && showInModalForMobile ? (
+      {isTestForceModal ? (
         <SuiModal
           isOpen={show}
-          closeOnOutsideClick
-          closeOnEscKeyDown
+          closeOnOutsideClick={false}
+          closeOnEscKeyDown={false}
           header={<img className={`${CLASS}-logo`} src={logo} alt="logo" />}
-          iconClose={<IconClose />}
+          // iconClose={<IconClose />}  // Removed for testingAB
           onClose={handleSaveExitClick}
           fitContent
           portalContainerId="sui-TcfFirstLayerModal"
@@ -171,9 +173,11 @@ export default function TcfFirstLayer({
 
 TcfFirstLayer.displayName = 'TcfFirstLayer'
 TcfFirstLayer.propTypes = {
-  onOpenSecondLayer: PropTypes.func,
-  onOpenCookiePolicyLayer: PropTypes.func,
-  onSaveUserConsent: PropTypes.func,
+  isTestAcceptedWithUserScroll: PropTypes.bool,
+  isTestForceModal: PropTypes.bool,
   logo: PropTypes.string,
+  onOpenCookiePolicyLayer: PropTypes.func,
+  onOpenSecondLayer: PropTypes.func,
+  onSaveUserConsent: PropTypes.func,
   showInModalForMobile: PropTypes.bool
 }

--- a/components/tcf/ui/src/FirstLayer/index.js
+++ b/components/tcf/ui/src/FirstLayer/index.js
@@ -120,12 +120,14 @@ export default function TcfFirstLayer({
 
   const Content = () => {
     return (
-      <div className={`${CLASS}-body`}>
-        <div
-          className={`${CLASS}-info`}
-          ref={textRef}
-          dangerouslySetInnerHTML={{__html: i18n.BODY}}
-        />
+      <>
+        <div className={`${CLASS}-body`}>
+          <div
+            className={`${CLASS}-info`}
+            ref={textRef}
+            dangerouslySetInnerHTML={{__html: i18n.BODY}}
+          />
+        </div>
         <div className={`${CLASS}-buttons`}>
           <SuiButton onClick={handleSettingsClick} design="outline">
             {i18n.CONFIGURE_BUTTON}
@@ -134,7 +136,7 @@ export default function TcfFirstLayer({
             {i18n.CONTINUE_NAVIGATION_BUTTON}
           </SuiButton>
         </div>
-      </div>
+      </>
     )
   }
 

--- a/components/tcf/ui/src/FirstLayer/index.scss
+++ b/components/tcf/ui/src/FirstLayer/index.scss
@@ -5,14 +5,15 @@
 @import '~@s-ui/react-molecule-notification/lib/index';
 @import './iconClose/index';
 
+$bxsh-tcf-first-layer: 0 0 8px 2px rgba(0, 0, 0, 0.15) !default;
 $fz-tcf-first-layer-base: $fz-s !default; // 14px
 $fz-tcf-first-layer-mobile: $fz-xs !default; // 12px
-$fz-tcf-first-layer-title: $fz-h5 !default; //18px
 $fz-tcf-first-layer-title-mobile: $fz-s !default; //14px
-$maw-tcf-first-layer: 1200px !default;
+$fz-tcf-first-layer-title: $fz-h5 !default; //18px
 $maw-tcf-first-layer-buttons: 200px + $p-xxxl !default;
 $maw-tcf-first-layer-logo: 114px !default;
-$bxsh-tcf-first-layer: 0 0 8px 2px rgba(0, 0, 0, 0.15) !default;
+$maw-tcf-first-layer: 1200px !default;
+$pb-tcf-second-layer-body: 80px;
 
 $base-class: '.sui-TcfFirstLayer';
 $base-class-modal: '#sui-TcfFirstLayerModal';
@@ -97,8 +98,26 @@ $base-class-modal: '#sui-TcfFirstLayerModal';
 }
 
 #{$base-class-modal} {
+  .sui-MoleculeModal-dialog {
+    position: relative;
+    padding-bottom: $pb-tcf-second-layer-body;
+  }
   .sui-MoleculeModal-content {
+    position: initial;
     margin-left: $m-l;
     margin-right: $m-l;
+
+    .sui-TcfFirstLayer-buttons {
+      position: absolute;
+      border-top: $bd-molecule-modal-header;
+      width: 100%;
+      padding: 12px 12px;
+      left: 0;
+      bottom: 0;
+
+      @include media-breakpoint-up(s) {
+        justify-content: flex-end;
+      }
+    }
   }
 }

--- a/components/tcf/ui/src/FirstLayer/index.scss
+++ b/components/tcf/ui/src/FirstLayer/index.scss
@@ -10,10 +10,12 @@ $fz-tcf-first-layer-base: $fz-s !default; // 14px
 $fz-tcf-first-layer-mobile: $fz-xs !default; // 12px
 $fz-tcf-first-layer-title-mobile: $fz-s !default; //14px
 $fz-tcf-first-layer-title: $fz-h5 !default; //18px
+$h-tcf-first-layer-footer: 88px;
 $maw-tcf-first-layer-buttons: 200px + $p-xxxl !default;
 $maw-tcf-first-layer-logo: 114px !default;
 $maw-tcf-first-layer: 1200px !default;
-$pb-tcf-second-layer-body: 80px;
+$p-tcf-first-layer-buttons--desktop: 24px 33px;
+$p-tcf-first-layer-buttons--mobile: 24px 0px;
 
 $base-class: '.sui-TcfFirstLayer';
 $base-class-modal: '#sui-TcfFirstLayerModal';
@@ -100,7 +102,7 @@ $base-class-modal: '#sui-TcfFirstLayerModal';
 #{$base-class-modal} {
   .sui-MoleculeModal-dialog {
     position: relative;
-    padding-bottom: $pb-tcf-second-layer-body;
+    padding-bottom: $h-tcf-first-layer-footer;
   }
   .sui-MoleculeModal-content {
     position: initial;
@@ -111,12 +113,14 @@ $base-class-modal: '#sui-TcfFirstLayerModal';
       position: absolute;
       border-top: $bd-molecule-modal-header;
       width: 100%;
-      padding: 12px 12px;
       left: 0;
       bottom: 0;
+      height: $h-tcf-first-layer-footer;
+      padding: $p-tcf-first-layer-buttons--mobile;
 
       @include media-breakpoint-up(s) {
         justify-content: flex-end;
+        padding: $p-tcf-first-layer-buttons--desktop;
       }
     }
   }

--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -7,10 +7,11 @@ const FirstLayer = React.lazy(() => import('../FirstLayer'))
 const SecondLayer = React.lazy(() => import('../SecondLayer'))
 
 export default function TCFContainer({
-  onCloseModal,
+  isTestAcceptedWithUserScroll = true,
+  isTestForceModal = false,
   logo,
-  showVendors,
-  showInModalForMobile
+  onCloseModal,
+  showVendors
 }) {
   const [showLayer, setShowLayer] = useState(0)
   const {uiVisible, loadUserConsent, saveUserConsent} = useConsent()
@@ -67,11 +68,12 @@ export default function TCFContainer({
       {showLayer === 1 && (
         <Suspense fallback={<div />}>
           <FirstLayer
+            isTestAcceptedWithUserScroll={isTestAcceptedWithUserScroll}
+            isTestForceModal={isTestForceModal}
             logo={logo}
-            onSaveUserConsent={handleSaveUserConsent}
-            onOpenSecondLayer={handleOpenSecondLayer}
             onOpenCookiePolicyLayer={handleOpenCookiePolicyLayer}
-            showInModalForMobile={showInModalForMobile}
+            onOpenSecondLayer={handleOpenSecondLayer}
+            onSaveUserConsent={handleSaveUserConsent}
           />
         </Suspense>
       )}
@@ -102,8 +104,9 @@ export default function TCFContainer({
 TCFContainer.displayName = 'TcfUi'
 
 TCFContainer.propTypes = {
-  onCloseModal: PropTypes.func,
-  showVendors: PropTypes.bool,
+  isTestAcceptedWithUserScroll: PropTypes.bool,
+  isTestForceModal: PropTypes.bool,
   logo: PropTypes.string,
-  showInModalForMobile: PropTypes.bool
+  onCloseModal: PropTypes.func,
+  showVendors: PropTypes.bool
 }

--- a/components/tcf/ui/src/index.js
+++ b/components/tcf/ui/src/index.js
@@ -16,13 +16,14 @@ const CONSENT_SCOPE = {
 }
 
 export default function TcfUi({
-  lang,
-  scope = CONSENT_SCOPE,
-  logo,
   isMobile,
-  showVendors,
+  isTestAcceptedWithUserScroll = true,
+  isTestForceModal = false,
+  lang,
+  logo,
   onCloseModal,
-  showInModalForMobile = false
+  scope = CONSENT_SCOPE,
+  showVendors
 }) {
   if (typeof window === 'undefined') {
     return null
@@ -30,10 +31,11 @@ export default function TcfUi({
   return (
     <ConsentProvider language={lang} isMobile={isMobile} scope={scope}>
       <TCFContainer
+        isTestAcceptedWithUserScroll={isTestAcceptedWithUserScroll}
+        isTestForceModal={isTestForceModal}
         logo={logo}
-        showVendors={showVendors}
         onCloseModal={onCloseModal}
-        showInModalForMobile={showInModalForMobile}
+        showVendors={showVendors}
       />
     </ConsentProvider>
   )
@@ -41,11 +43,12 @@ export default function TcfUi({
 
 TcfUi.displayName = 'TcfUi'
 TcfUi.propTypes = {
-  lang: PropTypes.string,
-  scope: PropTypes.object,
   isMobile: PropTypes.bool,
-  showVendors: PropTypes.bool,
+  isTestAcceptedWithUserScroll: PropTypes.bool,
+  isTestForceModal: PropTypes.bool,
+  lang: PropTypes.string,
   logo: PropTypes.string,
   onCloseModal: PropTypes.func,
-  showInModalForMobile: PropTypes.bool
+  scope: PropTypes.object,
+  showVendors: PropTypes.bool
 }

--- a/demo/tcf/ui/demo/index.js
+++ b/demo/tcf/ui/demo/index.js
@@ -2,11 +2,30 @@ import TcfUi from '../../../../components/tcf/ui/src'
 import React, {useState, useEffect, useContext} from 'react'
 import Context from '@s-ui/react-context'
 
+function removeCookie() {
+  const hostname = window.location.hostname || ''
+  const host = hostname
+    .split('.')
+    .reverse()
+    .filter((_, index) => index <= 1)
+    .reverse()
+    .join('.')
+  const cookieParts = [
+    `euconsent-v2=`,
+    `path=/`,
+    `domain=${host}`,
+    `expires= Thu, 01 Jan 1970 00:00:00 GMT`
+  ]
+  window.document.cookie = cookieParts.join(';')
+}
+
 const TcfUiDemo = () => {
   const {config = {}} = useContext(Context)
   const [isMobile, setIsMobile] = useState(false)
-  const [show, setShow] = useState(false)
-  const [showInModalForMobile, setShowInModalForMobile] = useState(false)
+  const [showVendors, setShowVendors] = useState(false)
+  const [forceModal, setForceModal] = useState(false)
+  const [show, setShow] = useState(true)
+  const [acceptedWithUserScroll, setAcceptedWithUserScroll] = useState(true)
   const [eventStatus, setEventStatus] = useState('empty')
   useEffect(() => {
     window.__tcfapi('addEventListener', 2, (tcData, success) => {
@@ -36,29 +55,66 @@ const TcfUiDemo = () => {
       >
         Mobile
       </button>
-      <button
-        onClick={() => {
-          setShow(true)
-        }}
-      >
-        Show Second layer
-      </button>
-      <button onClick={() => setShowInModalForMobile(prev => !prev)}>
-        {showInModalForMobile
-          ? 'Show first layer Notification variation'
-          : 'Show first layer Modal variation'}
-      </button>
+      {show && (
+        <button
+          onClick={() => {
+            setShowVendors(true)
+          }}
+        >
+          Show Second layer
+        </button>
+      )}
+      {!show && (
+        <>
+          <button
+            onClick={() => {
+              setAcceptedWithUserScroll(prev => !prev)
+            }}
+          >
+            Accepted with user scroll
+          </button>
+          <button
+            onClick={() => {
+              setForceModal(prev => !prev)
+            }}
+          >
+            Force modal not dismissable
+          </button>
+        </>
+      )}
       <div>
+        <p>Device: {isMobile ? 'mobile' : 'desktop'}</p>
+        <p>
+          acceptedWithUserScroll: {acceptedWithUserScroll ? 'true' : 'false'}
+        </p>
+        <p>forceModal: {forceModal ? 'true' : 'false'}</p>
         <b>Event Status:</b> {eventStatus}
       </div>
-      <TcfUi
-        lang={config.language}
-        logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
-        isMobile={isMobile}
-        showVendors={show}
-        onCloseModal={() => setShow(false)}
-        showInModalForMobile={showInModalForMobile}
-      />
+      <br />
+      <p>Unload the component to view some options</p>
+      <button
+        onClick={() => {
+          setShow(prev => {
+            if (prev) {
+              removeCookie()
+            }
+            return !prev
+          })
+        }}
+      >
+        {show ? 'remove cookies and unload component' : 'load component'}
+      </button>
+      {show && (
+        <TcfUi
+          lang={config.language}
+          logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
+          isMobile={isMobile}
+          showVendors={showVendors}
+          onCloseModal={() => setShowVendors(false)}
+          isTestAcceptedWithUserScroll={acceptedWithUserScroll}
+          isTestForceModal={forceModal}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Nowadays the tcf/ui component shows a bottom banner and dismisses with acceptance of consents if the user scrolls the page.

This PR modify the component to allow testing of these scenarios:
- Banner and dismiss if user scrolls
- Banner and don't dismiss if user scrolls
- Modal full page not dismissable without accepting or modify the consents explicitly

## Screenshots

### Mobile
**Banner**
*Small devices iPhone5*
![Screenshot 2020-10-06 at 16 29 03](https://user-images.githubusercontent.com/45286922/95216097-f7bfff80-07f1-11eb-921d-b4c15ad4f073.png)

*Large devices*
![Screenshot 2020-10-06 at 16 27 40](https://user-images.githubusercontent.com/45286922/95216033-ec6cd400-07f1-11eb-84f4-c43055294bec.png)

**Modal**
*Small devices iPhone5*
![Screenshot 2020-10-06 at 16 30 10](https://user-images.githubusercontent.com/45286922/95216238-1e7e3600-07f2-11eb-82d4-f3f3fd379569.png)
![tcf-scroll-modal](https://user-images.githubusercontent.com/45286922/95216245-21792680-07f2-11eb-9008-78b053d44405.gif)


*Large devices*
![Screenshot 2020-10-06 at 16 33 15](https://user-images.githubusercontent.com/45286922/95216306-32299c80-07f2-11eb-8ad2-d0b0592dc608.png)
![Screenshot 2020-10-06 at 16 33 23](https://user-images.githubusercontent.com/45286922/95216311-335ac980-07f2-11eb-9f2c-73298aaa8299.png)
![Screenshot 2020-10-06 at 16 33 32](https://user-images.githubusercontent.com/45286922/95216316-348bf680-07f2-11eb-8447-6a7900103bca.png)


### Desktop

**Banner**
![Screenshot 2020-10-06 at 16 27 49](https://user-images.githubusercontent.com/45286922/95216158-09090c00-07f2-11eb-8d1c-aa85bdff8f87.png)

**Modal**
![Screenshot 2020-10-06 at 16 34 11](https://user-images.githubusercontent.com/45286922/95216355-4077b880-07f2-11eb-851c-d84882d0eab2.png)

## Review steps
Demo is functional. You can use ```npm run dev tcf/ui```