### PR TITLE
Fix/vendor list go back

### DIFF
--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -2,6 +2,12 @@
 import React, {Suspense, useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {useConsent} from '@s-ui/react-tcf-services'
+import {
+  LAYER_BANNER,
+  LAYER_OFF,
+  LAYER_PURPOSES,
+  LAYER_VENDORS
+} from '../constants'
 
 const FirstLayer = React.lazy(() => import('../FirstLayer'))
 const SecondLayer = React.lazy(() => import('../SecondLayer'))
@@ -11,16 +17,16 @@ export default function TCFContainer({
   isTestForceModal = false,
   logo,
   onCloseModal,
-  showVendors
+  showPurposesLayer
 }) {
-  const [showLayer, setShowLayer] = useState(0)
+  const [showLayer, setShowLayer] = useState(LAYER_OFF)
   const {uiVisible, loadUserConsent, saveUserConsent} = useConsent()
   useEffect(() => {
-    if (showVendors) {
+    if (showPurposesLayer) {
       uiVisible({visible: true})
-      setShowLayer(2)
+      setShowLayer(LAYER_PURPOSES)
     }
-  }, [showVendors, uiVisible])
+  }, [showPurposesLayer, uiVisible])
 
   useEffect(() => {
     async function checkConsentStatus() {
@@ -28,44 +34,44 @@ export default function TCFContainer({
       const {valid} = userConsent
       if (!valid) {
         uiVisible({visible: true})
-        setShowLayer(1)
+        setShowLayer(LAYER_BANNER)
       }
     }
     checkConsentStatus().catch(() => {
-      setShowLayer(0)
+      setShowLayer(LAYER_OFF)
     })
   }, [])
 
   const handleOpenSecondLayer = () => {
-    setShowLayer(2)
+    setShowLayer(LAYER_PURPOSES)
   }
   const handleVendorsClick = () => {
-    setShowLayer(3)
+    setShowLayer(LAYER_VENDORS)
   }
   const handleSecondLayerGoBack = () => {
-    if (showVendors) {
+    if (showPurposesLayer) {
       onCloseModal && onCloseModal()
-      setShowLayer(0)
+      setShowLayer(LAYER_OFF)
     } else {
-      setShowLayer(1)
+      setShowLayer(LAYER_BANNER)
     }
   }
   const handleThirdLayerGoBack = () => {
-    setShowLayer(2)
+    setShowLayer(LAYER_PURPOSES)
   }
   const handleOpenCookiePolicyLayer = () => {
-    setShowLayer(3)
+    setShowLayer(LAYER_VENDORS)
   }
   const handleSaveUserConsent = async () => {
     await saveUserConsent()
     uiVisible({visible: false})
     onCloseModal && onCloseModal()
-    setShowLayer(0)
+    setShowLayer(LAYER_OFF)
   }
 
   return (
     <>
-      {showLayer === 1 && (
+      {showLayer === LAYER_BANNER && (
         <Suspense fallback={<div />}>
           <FirstLayer
             isTestAcceptedWithUserScroll={isTestAcceptedWithUserScroll}
@@ -77,7 +83,7 @@ export default function TCFContainer({
           />
         </Suspense>
       )}
-      {showLayer === 2 && (
+      {showLayer === LAYER_PURPOSES && (
         <Suspense fallback={<div />}>
           <SecondLayer
             logo={logo}
@@ -87,7 +93,7 @@ export default function TCFContainer({
           />
         </Suspense>
       )}
-      {showLayer === 3 && (
+      {showLayer === LAYER_VENDORS && (
         <Suspense fallback={<div />}>
           <SecondLayer
             isVendorLayer
@@ -108,5 +114,5 @@ TCFContainer.propTypes = {
   isTestForceModal: PropTypes.bool,
   logo: PropTypes.string,
   onCloseModal: PropTypes.func,
-  showVendors: PropTypes.bool
+  showPurposesLayer: PropTypes.bool
 }

--- a/components/tcf/ui/src/TCFContainer/TCFContainer.js
+++ b/components/tcf/ui/src/TCFContainer/TCFContainer.js
@@ -20,11 +20,12 @@ export default function TCFContainer({
   showPurposesLayer
 }) {
   const [showLayer, setShowLayer] = useState(LAYER_OFF)
+  const [vendorsLayerBackTo, setVendorsLayerBackTo] = useState(LAYER_OFF)
   const {uiVisible, loadUserConsent, saveUserConsent} = useConsent()
   useEffect(() => {
     if (showPurposesLayer) {
       uiVisible({visible: true})
-      setShowLayer(LAYER_PURPOSES)
+      changeLayer(LAYER_PURPOSES)
     }
   }, [showPurposesLayer, uiVisible])
 
@@ -34,39 +35,46 @@ export default function TCFContainer({
       const {valid} = userConsent
       if (!valid) {
         uiVisible({visible: true})
-        setShowLayer(LAYER_BANNER)
+        changeLayer(LAYER_BANNER)
       }
     }
     checkConsentStatus().catch(() => {
-      setShowLayer(LAYER_OFF)
+      changeLayer(LAYER_OFF)
     })
   }, [])
 
+  const changeLayer = to => {
+    if (to === LAYER_VENDORS) {
+      setVendorsLayerBackTo(showLayer)
+    }
+    setShowLayer(to)
+  }
+
   const handleOpenSecondLayer = () => {
-    setShowLayer(LAYER_PURPOSES)
+    changeLayer(LAYER_PURPOSES)
   }
   const handleVendorsClick = () => {
-    setShowLayer(LAYER_VENDORS)
+    changeLayer(LAYER_VENDORS)
   }
   const handleSecondLayerGoBack = () => {
     if (showPurposesLayer) {
       onCloseModal && onCloseModal()
-      setShowLayer(LAYER_OFF)
+      changeLayer(LAYER_OFF)
     } else {
-      setShowLayer(LAYER_BANNER)
+      changeLayer(LAYER_BANNER)
     }
   }
   const handleThirdLayerGoBack = () => {
-    setShowLayer(LAYER_PURPOSES)
+    changeLayer(vendorsLayerBackTo)
   }
   const handleOpenCookiePolicyLayer = () => {
-    setShowLayer(LAYER_VENDORS)
+    changeLayer(LAYER_VENDORS)
   }
   const handleSaveUserConsent = async () => {
     await saveUserConsent()
     uiVisible({visible: false})
     onCloseModal && onCloseModal()
-    setShowLayer(LAYER_OFF)
+    changeLayer(LAYER_OFF)
   }
 
   return (

--- a/components/tcf/ui/src/constants.js
+++ b/components/tcf/ui/src/constants.js
@@ -1,0 +1,4 @@
+export const LAYER_OFF = 0
+export const LAYER_BANNER = 1
+export const LAYER_PURPOSES = 2
+export const LAYER_VENDORS = 3

--- a/components/tcf/ui/src/index.js
+++ b/components/tcf/ui/src/index.js
@@ -35,7 +35,7 @@ export default function TcfUi({
         isTestForceModal={isTestForceModal}
         logo={logo}
         onCloseModal={onCloseModal}
-        showVendors={showVendors}
+        showPurposesLayer={showVendors}
       />
     </ConsentProvider>
   )


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Actually, when clicking on "go back" button on the third layer ("vendors checking"), it's always going back to the second layer ("purposes"), no matter if it was being opened from the first layer ("banner").

This PR changes that behavior in order to go back to the last shown layer.

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3616

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

**1) when vendors layer is opened from the first layer ("banner"), clicking on "go back" will return to the first layer**
![](https://i.gyazo.com/f6c28ec7465dfb1092f2e1f13cc18fdf.gif)

**2) when vendors layer is opened from the second layer ("purposes"), clicking on "go back" will return to the second layer**
![](https://i.gyazo.com/18977be454bd68456f37226c9ee0bd50.gif)


## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

- can be reviewed locally
`npm run dev tcf/ui`

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/KZ0TfAhzJbD0c/giphy.gif)