### PR TITLE
feat(tcf/ui): add tcf reporter

### DIFF
--- a/components/tcf/ui/src/index.js
+++ b/components/tcf/ui/src/index.js
@@ -22,6 +22,7 @@ export default function TcfUi({
   lang,
   logo,
   onCloseModal,
+  reporter,
   scope = CONSENT_SCOPE,
   showVendors
 }) {
@@ -29,7 +30,12 @@ export default function TcfUi({
     return null
   }
   return (
-    <ConsentProvider language={lang} isMobile={isMobile} scope={scope}>
+    <ConsentProvider
+      language={lang}
+      isMobile={isMobile}
+      reporter={reporter}
+      scope={scope}
+    >
       <TCFContainer
         isTestAcceptedWithUserScroll={isTestAcceptedWithUserScroll}
         isTestForceModal={isTestForceModal}
@@ -49,6 +55,7 @@ TcfUi.propTypes = {
   lang: PropTypes.string,
   logo: PropTypes.string,
   onCloseModal: PropTypes.func,
+  reporter: PropTypes.func,
   scope: PropTypes.object,
   showVendors: PropTypes.bool
 }

--- a/demo/tcf/ui/demo/index.js
+++ b/demo/tcf/ui/demo/index.js
@@ -1,5 +1,5 @@
 import TcfUi from '../../../../components/tcf/ui/src'
-import React, {useState, useEffect, useContext} from 'react'
+import React, {useState, useEffect, useContext, useRef} from 'react'
 import Context from '@s-ui/react-context'
 
 function removeCookie() {
@@ -27,6 +27,10 @@ const TcfUiDemo = () => {
   const [show, setShow] = useState(true)
   const [acceptedWithUserScroll, setAcceptedWithUserScroll] = useState(true)
   const [eventStatus, setEventStatus] = useState('empty')
+  const reporter = useRef((event, payload) =>
+    console.log('BorosTcf ', {event, payload})
+  )
+
   useEffect(() => {
     window.__tcfapi('addEventListener', 2, (tcData, success) => {
       if (
@@ -109,6 +113,7 @@ const TcfUiDemo = () => {
           lang={config.language}
           logo="https://frtassets.fotocasa.es/img/fotocasa_logo.svg"
           isMobile={isMobile}
+          reporter={reporter.current}
           showVendors={showVendors}
           onCloseModal={() => setShowVendors(false)}
           isTestAcceptedWithUserScroll={acceptedWithUserScroll}


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Following the changes made in #316 , this adds the `reporter` parameter to the TCF UI to provide it to the TCF Services.

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3594

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* No behavioral changes.
* TCF integration can be configured with an external reporter which will be able to receive TCF signals to collect metrics and analyze TCF operations.

Sample added in the UI Demo with a `console.log` reporter
![image](https://user-images.githubusercontent.com/20399660/96575051-8c396000-12d0-11eb-8829-3afe9389eda5.png)

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

`npm run dev tcf/ui`

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/xUNd9HdWFGZTkNEclG/giphy.gif)