### PR TITLE
feat(tcf/ui): update for tcf/services major release

### DIFF
--- a/components/tcf/ui/package.json
+++ b/components/tcf/ui/package.json
@@ -14,7 +14,7 @@
     "@s-ui/react-atom-switch": "1",
     "@s-ui/react-molecule-modal": "1",
     "@s-ui/react-molecule-notification": "1",
-    "@s-ui/react-tcf-services": "1"
+    "@s-ui/react-tcf-services": "2"
   },
   "keywords": [],
   "author": "",

--- a/components/tcf/ui/src/FirstLayer/index.js
+++ b/components/tcf/ui/src/FirstLayer/index.js
@@ -22,10 +22,9 @@ export default function TcfFirstLayer({
   const {
     isMobile,
     language,
-    loadUserConsent,
-    updateUserConsent,
-    getVendorList,
-    getScope
+    updatePurpose,
+    updateSpecialFeature,
+    updateVendor
   } = useConsent()
   const [show, setShow] = useState(true)
   const cookiesPolicyLink = useRef()
@@ -81,35 +80,9 @@ export default function TcfFirstLayer({
   }
 
   const handleSaveExitClick = async () => {
-    const [userConsent, vendorList, scope] = await Promise.all([
-      loadUserConsent(),
-      getVendorList(),
-      getScope()
-    ])
-    scope.purposes = scope.purposes || Object.keys(vendorList.purposes)
-    scope.purposes.forEach(key => {
-      userConsent.purpose.consents[key] = true
-      userConsent.purpose.legitimateInterests[key] = true
-    })
-
-    scope.specialFeatures =
-      scope.specialFeatures || Object.keys(vendorList.specialFeatures)
-    scope.specialFeatures.forEach(
-      key => (userConsent.specialFeatures[key] = true)
-    )
-
-    Object.keys(vendorList.vendors).forEach(key => {
-      userConsent.vendor.consents[key] = true
-      userConsent.vendor.legitimateInterests[key] = true
-    })
-    updateUserConsent({
-      purpose: userConsent.purpose,
-      vendor: userConsent.vendor,
-      specialFeatures: userConsent.specialFeatures,
-      allPurposes: true,
-      allVendors: true,
-      allSpecialFeatures: true
-    })
+    updatePurpose({consent: true})
+    updateSpecialFeature({consent: true})
+    updateVendor({consent: true, legitimateInterest: true})
     handleCloseModal()
     onSaveUserConsent()
   }


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Follows the `tcf/ui` major release from this change: https://github.com/SUI-Components/adevinta-spain-components/pull/319

This PR is an update to be applied after the services major release, that will:
- remove the "update the consent values logic" from the UI, as it has to be done in the services use cases
- the UI will apply the user changes to the services use cases and get the react components state synced using the services layer "consent draft" state, which will be calculated so the UI has no need to do the logic

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3561

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

* no behavioral changes, the change is only a "responsability" change to the services layer

## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

`npm run dev tcf/ui -- --link-package=/Users/alex.castells/projects/adit/adevinta-spain-components/components/tcf/services`

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

- cannot be merged until #319 is merged and tcf/services deployed to NPM, and a new commit to this PR will be needed in order to increase the major version of the services dependency

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://gifmaniacos.es/wp-content/uploads/2017/08/bolas-bolitas-pelotas-pelotitas-gifmaniacos.es-35.gif)