### PR TITLE
feat(tcf/services): improve vendors acceptance logic

### DIFF
--- a/components/tcf/services/src/application/service/LoadUserConsentUseCase.js
+++ b/components/tcf/services/src/application/service/LoadUserConsentUseCase.js
@@ -1,10 +1,60 @@
 class LoadUserConsentUseCase {
   constructor({repository}) {
     this._repository = repository
+    this._draftReady = false
+    this._cachedUserConsent = null
   }
 
   execute() {
-    return this._repository.loadUserConsent()
+    return this._draftReady
+      ? Promise.resolve(this._repository.loadConsentDraft())
+      : this._loadUserConsent()
+  }
+
+  _loadUserConsent() {
+    this._cachedUserConsent =
+      this._cachedUserConsent ||
+      this._repository
+        .loadUserConsent()
+        .then(userConsent =>
+          userConsent.isNew
+            ? this._initializeWithVendorList({userConsent})
+            : userConsent
+        )
+        .then(userConsent => {
+          this._repository.initConsentDraft({userConsent})
+          this._draftReady = true
+          return this._repository.loadConsentDraft()
+        })
+    return this._cachedUserConsent
+  }
+
+  _initializeWithVendorList({userConsent}) {
+    return this._repository.getVendorList().then(vendorList => {
+      userConsent.purpose = {consents: {}, legitimateInterests: {}}
+      userConsent.vendor = {
+        consents: {},
+        legitimateInterests: {},
+        purposes: {},
+        specialFeatures: {}
+      }
+      userConsent.specialFeatures = {}
+      Object.keys(vendorList.purposes).forEach(key => {
+        userConsent.purpose.consents[key] = false
+        userConsent.purpose.legitimateInterests[key] = false
+      })
+      Object.keys(vendorList.specialFeatures).forEach(key => {
+        userConsent.specialFeatures[key] = false
+      })
+      Object.keys(vendorList.vendors).forEach(key => {
+        userConsent.vendor.consents[key] = false
+        userConsent.vendor.legitimateInterests[key] = true
+        userConsent.vendor.purposes[key] = vendorList.vendors[key].purposes
+        userConsent.vendor.specialFeatures[key] =
+          vendorList.vendors[key].specialFeatures
+      })
+      return userConsent
+    })
   }
 }
 

--- a/components/tcf/services/src/application/service/SaveUserConsentUseCase.js
+++ b/components/tcf/services/src/application/service/SaveUserConsentUseCase.js
@@ -4,7 +4,9 @@ class SaveUserConsentUseCase {
   }
 
   execute() {
-    return this._repository.saveUserConsent()
+    const draft = this._repository.loadConsentDraft()
+    const userConsent = draft.asUserConsent()
+    return this._repository.saveUserConsent(userConsent)
   }
 }
 

--- a/components/tcf/services/src/application/service/UpdateConsentPurposeUseCase.js
+++ b/components/tcf/services/src/application/service/UpdateConsentPurposeUseCase.js
@@ -4,6 +4,7 @@ export class UpdateConsentPurposeUseCase {
   }
 
   execute({id, consent}) {
-    return this._repository.updatePurpose({id, consent})
+    const draft = this._repository.loadConsentDraft()
+    draft.updatePurposes({id, consent})
   }
 }

--- a/components/tcf/services/src/application/service/UpdateConsentSpecialFeatureUseCase.js
+++ b/components/tcf/services/src/application/service/UpdateConsentSpecialFeatureUseCase.js
@@ -4,6 +4,7 @@ export class UpdateConsentSpecialFeatureUseCase {
   }
 
   execute({id, consent}) {
-    return this._repository.updateSpecialFeature({id, consent})
+    const draft = this._repository.loadConsentDraft()
+    draft.updateSpecialFeatures({id, consent})
   }
 }

--- a/components/tcf/services/src/application/service/UpdateConsentVendorUseCase.js
+++ b/components/tcf/services/src/application/service/UpdateConsentVendorUseCase.js
@@ -4,6 +4,7 @@ export class UpdateConsentVendorUseCase {
   }
 
   execute({id, consent, legitimateInterest}) {
-    return this._repository.updateVendor({id, consent, legitimateInterest})
+    const draft = this._repository.loadConsentDraft()
+    draft.updateVendors({id, consent, legitimateInterest})
   }
 }

--- a/components/tcf/services/src/core/service/isBoolean.js
+++ b/components/tcf/services/src/core/service/isBoolean.js
@@ -1,0 +1,1 @@
+export const isBoolean = data => typeof data === 'boolean'

--- a/components/tcf/services/src/domain/ConsentDraft.js
+++ b/components/tcf/services/src/domain/ConsentDraft.js
@@ -1,0 +1,105 @@
+import {isBoolean} from '../core/service/isBoolean'
+
+export class ConsentDraft {
+  constructor({
+    scope = {},
+    purpose = {consents: {}, legitimateInterests: {}},
+    vendor = {consents: {}, legitimateInterests: {}},
+    specialFeatures = {},
+    vendorTouched = true
+  } = {}) {
+    this._scopedPurposes = scope.purposes || []
+    this._scopedSpecialFeatures = scope.specialFeatures || []
+    this._purpose = purpose
+    this._vendor = vendor
+    this._specialFeatures = specialFeatures
+    this._vendorTouched = vendorTouched
+  }
+
+  get purpose() {
+    return this._purpose
+  }
+
+  get specialFeatures() {
+    return this._specialFeatures
+  }
+
+  get vendor() {
+    return this._vendor
+  }
+
+  asUserConsent() {
+    return {
+      purpose: {
+        consents: this._purpose.consents,
+        legitimateInterests: this._purpose.legitimateInterests
+      },
+      specialFeatures: this._specialFeatures,
+      vendor: {
+        consents: this._vendor.consents,
+        legitimateInterests: this._vendor.legitimateInterests
+      }
+    }
+  }
+
+  updatePurposes({id, consent}) {
+    if (!id) {
+      this._scopedPurposes.forEach(key => {
+        this._purpose.consents[key] = consent
+        this._purpose.legitimateInterests[key] = consent
+      })
+    } else {
+      this._purpose.consents[id] = consent
+      this._purpose.legitimateInterests[id] = consent
+    }
+    this._refreshVendors()
+  }
+
+  updateSpecialFeatures({id, consent}) {
+    if (!id) {
+      this._scopedSpecialFeatures.forEach(key => {
+        this._specialFeatures[key] = consent
+      })
+    } else {
+      this._specialFeatures[id] = consent
+    }
+    this._refreshVendors()
+  }
+
+  updateVendors({id, consent, legitimateInterest}) {
+    if (!id) {
+      if (isBoolean(consent)) {
+        Object.keys(this._vendor.consents).forEach(key => {
+          this._vendor.consents[key] = consent
+        })
+      }
+      if (isBoolean(legitimateInterest)) {
+        Object.keys(this._vendor.legitimateInterests).forEach(key => {
+          this._vendor.legitimateInterests[key] = legitimateInterest
+        })
+      }
+    } else {
+      isBoolean(consent) && (this._vendor.consents[id] = consent)
+      isBoolean(legitimateInterest) &&
+        (this._vendor.legitimateInterests[id] = legitimateInterest)
+    }
+    this._vendorTouched = true
+  }
+
+  _refreshVendors() {
+    if (!this._vendorTouched) {
+      Object.keys(this._vendor.consents).forEach(key => {
+        const acceptedByPurposes = this._vendor.purposes[key].every(
+          purpose => this._purpose.consents[purpose] === true
+        )
+        const acceptedBySpecialFeatures = this._vendor.specialFeatures[
+          key
+        ].every(
+          specialFeature => this._specialFeatures[specialFeature] === true
+        )
+        this._vendor.consents[key] =
+          acceptedByPurposes && acceptedBySpecialFeatures
+      })
+    }
+  }
+}

--- a/components/tcf/services/src/index.js
+++ b/components/tcf/services/src/index.js
@@ -14,15 +14,15 @@ function ConsentProvider({language, isMobile, reporter, scope, children}) {
   const loadConsentDraft = () => service.current.loadConsentDraft()
   const loadUserConsent = () => service.current.loadUserConsent()
   const getVendorList = () => service.current.getVendorList()
-  const getScope = async () => {
-    if (scope) return scope
-    const vendorList = await getVendorList()
-    const defaultScope = {
-      purposes: Object.keys(vendorList.purposes),
-      specialFeatures: Object.keys(vendorList.specialFeatures)
-    }
-    return defaultScope
-  }
+  const getScope = () =>
+    Promise.resolve().then(
+      () =>
+        scope ||
+        getVendorList().then(vendorList => ({
+          purposes: Object.keys(vendorList.purposes),
+          specialFeatures: Object.keys(vendorList.specialFeatures)
+        }))
+    )
   const saveUserConsent = () => service.current.saveUserConsent()
   const updatePurpose = ({id, consent}) =>
     service.current.updatePurpose({id, consent})

--- a/components/tcf/services/src/infrastructure/reporter/eventReporter.js
+++ b/components/tcf/services/src/infrastructure/reporter/eventReporter.js
@@ -5,4 +5,4 @@ const noopReporter = () => null
 const asyncReporter = reporter => (eventName, payload) =>
   Promise.resolve()
     .then(() => reporter(eventName, payload))
-    .catch(ignored => null)
+    .catch(() => null)

--- a/test/tcf/services/application/service/loadConsentDraftUseCase.test.js
+++ b/test/tcf/services/application/service/loadConsentDraftUseCase.test.js
@@ -32,11 +32,24 @@ describe('LoadConsentDraftUseCase test', () => {
       tcfApi: borosTCFMock.init(),
       scope: givenScope
     })
+    repository.initConsentDraft({userConsent: givenConsent})
     const useCase = new LoadConsentDraftUseCase({repository})
-    const userConsent = await repository.loadUserConsent()
+    const {
+      purpose,
+      vendor,
+      specialFeatures
+    } = await repository.loadUserConsent()
     let draft = useCase.execute()
-    expect(draft).toEqual(userConsent)
-    repository.updateSpecialFeature({consent: false})
+    expect({
+      purpose: draft.purpose,
+      vendor: draft.vendor,
+      specialFeatures: draft.specialFeatures
+    }).toEqual({
+      purpose,
+      vendor,
+      specialFeatures
+    })
+    draft.updateSpecialFeatures({consent: false})
     draft = useCase.execute()
     expect(draft.specialFeatures[1]).toBeFalsy()
   })

--- a/test/tcf/services/application/service/loadUserConsentUseCase.test.js
+++ b/test/tcf/services/application/service/loadUserConsentUseCase.test.js
@@ -47,8 +47,20 @@ describe('LoadUserConsentUseCase test', () => {
     const loadUserConsentUseCase = new LoadUserConsentUseCase({
       repository: tcfRepositoryMock
     })
-    const userConsent = await loadUserConsentUseCase.execute()
-    expect(userConsent).toBe(givenUserConsent)
+    const {
+      purpose,
+      vendor,
+      specialFeatures
+    } = await loadUserConsentUseCase.execute()
     expect(loadUserConsentSpy).toHaveBeenCalledTimes(1)
+    expect({
+      purpose: givenUserConsent.purpose,
+      vendor: givenUserConsent.vendor,
+      specialFeatures: givenUserConsent.specialFeatures
+    }).toEqual({
+      purpose,
+      vendor,
+      specialFeatures
+    })
   })
 })

--- a/test/tcf/services/application/service/saveUserConsentUseCase.test.js
+++ b/test/tcf/services/application/service/saveUserConsentUseCase.test.js
@@ -47,15 +47,7 @@ describe('SaveUserConsentUseCase test', () => {
     const saveUserConsentUseCase = new SaveUserConsentUseCase({
       repository: tcfRepositoryMock
     })
-    await tcfRepositoryMock.loadUserConsent()
-    tcfRepositoryMock.updatePurpose({consent: false})
-    tcfRepositoryMock.updateVendor({
-      consent: false,
-      legitimateInterest: false
-    })
-    tcfRepositoryMock.updateSpecialFeature({
-      consent: false
-    })
+    tcfRepositoryMock.initConsentDraft({userConsent})
     await saveUserConsentUseCase.execute()
     expect(saveUserConsentSpy).toHaveBeenCalledTimes(1)
     expect(saveUserConsentSpy).toHaveBeenCalledWith(userConsent)


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Actually, vendors are automatically updated only taking care about the second layer, but the user may have selected its preferences about advertising vendors and if the user has selected them, we should not modify them no matter if the user changes its purpose preferences.

P.ex: this happens if I accept all vendors, and later I reject the purpose to "create an advertising profile" and I open again the vendors layer:
![image](https://user-images.githubusercontent.com/20399660/97432773-c92ed380-191c-11eb-92fa-57b28ce63ecb.png)

Also, the vendors automatic update is not taking care of the GVL purposes used by each vendor that can be checked in each vendors node of the GVL here https://vendorlist.consensu.org/v2/vendor-list.json 

So this PR also fixes that, by:
- applying automatic vendor acceptance/rejection taking care about the user's selection in the second layer on purposes and special features
- if the user modifies manually the vendor preferences, no more automatic updates are done to the vendor preferences

Also, following this changes: #319 which started moving/centralizing the "business logic" from the UI to the services layer, now the main logic is moved to a new domain object, which represents the "consent draft" abstraction, so:
- the repository now is only used to save and retrieve data, but does not implement logic on the domain abstraction
- the use case services now use the repository to get data and apply service logic
- the ConsentDraft implements the logics for updating its owned data according to the user preferences draft before being accepted and transformed to a user consent to be saved

Also replaces all `async/await`usages and transform the to promises to improve babel transformations and debugging code

## Solves ticket/s
<!--- Optionally, add the tickets (jira, mantis, trello, ...) that are related to this PR -->

* https://jira.scmspain.com/browse/PSP-3561

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

- saving directly from the first layer (faldón) without consent or vendor preferences, saves a consent with all items consented:
![image](https://user-images.githubusercontent.com/20399660/97433563-ffb91e00-191d-11eb-91c0-93e5fefaf87c.png)

- (as vendors are rejected by default according to IAB specifications) modifying purposes and/or special features, without modifying the vendors, updates automatically the vendors that use those purposes or special features to be accepted or rejected according to what the vendors are declared to use in the GVL.
P.ex. accepting all purposes but rejecting special features:
![image](https://user-images.githubusercontent.com/20399660/97433799-5a527a00-191e-11eb-999b-0ba7073e0158.png)

- accepting/rejecting vendors and after modifying purpose or special features does not apply automatically any change to the vendors and they are kept as the user has defined
P.ex: accepting all vendors except the first one and after accepting all purposes and special features, the first vendor is still rejected:
![image](https://user-images.githubusercontent.com/20399660/97434024-ae5d5e80-191e-11eb-806c-8d7a82788e45.png)


## Review steps
<!--- Nice to have, add the steps you've reproduced for a visual test in your development environment, or loc, consider adding screenshots ... -->

`npm run dev tcf/ui -- --link-package=components/tcf/services`

## Further considerations
<!--- If applies, add information of breaking changes, agreed deploy timings, ...  -->

- a case of study has been raised to the product team: what should happen with vendors using special features that are not in the Adevinta scope? (we're using only the specialFeature.id=1, and the GVL declares the 2 and can declare more to be used by the vendors but if they are not in the Adevinta scope, an user will never be able to accept them, and according to legal basis, we cannot accept them automatically)

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/MY1VeGtRRDHpNROdgO/giphy.gif)