### PR TITLE
fix(tcf/ui): remove forgotten characters

### DIFF
--- a/components/tcf/ui/src/FirstLayer/index.js
+++ b/components/tcf/ui/src/FirstLayer/index.js
@@ -102,7 +102,6 @@ export default function TcfFirstLayer({
       >
         <Content />
       </SuiModal>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Remove forgotten characters in the return statement.

**Before**
![Screenshot 2020-11-02 at 15 34 32](https://user-images.githubusercontent.com/45286922/97880732-d2a3ab80-1d21-11eb-880e-c68c5a73c1a2.png)

**After**
![Screenshot 2020-11-02 at 15 35 06](https://user-images.githubusercontent.com/45286922/97880752-d800f600-1d21-11eb-9097-8ed17324e379.png)
