### PR TITLE
feat(form/builder): add multipicker field

### DIFF
--- a/components/form/builder/package.json
+++ b/components/form/builder/package.json
@@ -18,6 +18,7 @@
     "@s-ui/react-molecule-button-group-field": "1",
     "@s-ui/react-molecule-checkbox-field": "2",
     "@s-ui/react-molecule-dropdown-option": "1",
+    "@s-ui/react-molecule-field": "1",
     "@s-ui/react-molecule-input-field": "3",
     "@s-ui/react-molecule-radio-button-field": "1",
     "@s-ui/react-molecule-radio-button-group": "1",

--- a/components/form/builder/src/MultiPicker/index.js
+++ b/components/form/builder/src/MultiPicker/index.js
@@ -1,0 +1,106 @@
+import React from 'react'
+
+import PropTypes from 'prop-types'
+import {field, createComponentMemo} from '../prop-types'
+import MoleculeCheckboxField from '@s-ui/react-molecule-checkbox-field'
+import MoleculeField from '@s-ui/react-molecule-field'
+import IconCheck from '../Icons/IconCheck'
+
+const Multipicker = ({
+  multipicker,
+  tabIndex,
+  onChange,
+  onBlur,
+  errors,
+  alerts,
+  renderer
+}) => {
+  const errorMessages = errors[multipicker.id]
+  const alertMessages = alerts[multipicker.id]
+
+  const onChangeCallback = e => {
+    const targetId = e.target.id
+    const checked = e.target.checked
+    let newValue = []
+
+    if (checked) {
+      newValue = [...multipicker.value, targetId]
+    } else {
+      newValue = multipicker.value.filter(id => id !== targetId)
+    }
+    return onChange(multipicker.id, newValue)
+  }
+
+  const onBlurCallback = () => onBlur(multipicker.id)
+
+  const multipickerProps = {
+    id: multipicker.id,
+    label: multipicker.label,
+    value: multipicker.value,
+    checkedIcon: IconCheck,
+    onChange: onChangeCallback,
+    onBlur: onBlurCallback,
+    tabIndex: tabIndex,
+    intermediate: false,
+    ...(multipicker.disabled && {
+      disabled: true
+    }),
+    ...(multipicker.hidden && {
+      hidden: true
+    }),
+    ...(!!errorMessages && {
+      errorText: errorMessages.join('\n')
+    }),
+    ...(!!alertMessages && {
+      alertText: alertMessages.join('\n')
+    })
+  }
+
+  if (multipickerProps.hidden) {
+    return null
+  }
+
+  const rendererResponse = renderer({
+    id: multipicker.id,
+    innerProps: multipickerProps
+  })
+
+  // render custom component
+  if (React.isValidElement(rendererResponse)) {
+    return rendererResponse
+  }
+
+  // render SUI component
+  return (
+    <div
+      className={`sui-FormBuilder-field sui-FormBuilder-Multipicker sui-FormBuilder-${multipickerProps.id ||
+        tabIndex}`}
+    >
+      <MoleculeField {...multipickerProps}>
+        {multipicker.datalist.map(item => (
+          <MoleculeCheckboxField
+            {...multipickerProps}
+            {...rendererResponse}
+            key={item.value}
+            label={item.text}
+            id={item.value}
+            checked={multipicker.value.some(id => id === item.value)}
+          />
+        ))}
+      </MoleculeField>
+    </div>
+  )
+}
+
+Multipicker.displayName = 'Switch'
+Multipicker.propTypes = {
+  tabIndex: PropTypes.number,
+  multipicker: field,
+  onChange: PropTypes.func,
+  onBlur: PropTypes.func,
+  errors: PropTypes.object,
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
+}
+
+export default React.memo(Multipicker, createComponentMemo('multipicker'))

--- a/components/form/builder/src/MultiPicker/index.js
+++ b/components/form/builder/src/MultiPicker/index.js
@@ -84,7 +84,7 @@ const Multipicker = ({
             key={item.value}
             label={item.text}
             id={item.value}
-            checked={multipicker.value.some(id => id === item.value)}
+            checked={multipicker?.value?.some(id => id === item.value)}
           />
         ))}
       </MoleculeField>
@@ -92,7 +92,7 @@ const Multipicker = ({
   )
 }
 
-Multipicker.displayName = 'Switch'
+Multipicker.displayName = 'Multipicker'
 Multipicker.propTypes = {
   tabIndex: PropTypes.number,
   multipicker: field,

--- a/components/form/builder/src/MultiPicker/index.scss
+++ b/components/form/builder/src/MultiPicker/index.scss
@@ -1,0 +1,2 @@
+@import '~@s-ui/react-molecule-checkbox-field/lib/index';
+@import '~@s-ui/react-molecule-field/lib/index';

--- a/components/form/builder/src/ProxyField/index.js
+++ b/components/form/builder/src/ProxyField/index.js
@@ -9,6 +9,7 @@ import TextField from '../Standard/Fields/Text'
 import NumericField from '../Standard/Fields/Numeric'
 import FieldSetField from '../Standard/Fields/FieldSet'
 import PickerField from '../Standard/Fields/Picker'
+import MultiPickerField from '../Standard/Fields/Multipicker'
 
 const ProxyField = ({
   field,
@@ -60,6 +61,18 @@ const ProxyField = ({
 
     case FIELDS.PICKER:
       Field = PickerField({
+        field,
+        tabIndex,
+        onChange,
+        onBlur,
+        errors,
+        alerts,
+        renderer
+      })
+      break
+
+    case FIELDS.MULTIPICKER:
+      Field = MultiPickerField({
         field,
         tabIndex,
         onChange,

--- a/components/form/builder/src/Standard/Fields/Multipicker/index.js
+++ b/components/form/builder/src/Standard/Fields/Multipicker/index.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import Multipicker from '../../../Multipicker'
+
+const MultipickerField = ({
+  field,
+  tabIndex,
+  onChange,
+  onBlur,
+  errors,
+  alerts,
+  renderer
+}) => {
+  return (
+    <Multipicker
+      multipicker={field}
+      onChange={onChange}
+      onBlur={onBlur}
+      tabIndex={tabIndex}
+      errors={errors}
+      alerts={alerts}
+      renderer={renderer}
+    />
+  )
+}
+
+MultipickerField.propTypes = {
+  onChange: PropTypes.func,
+  onBlur: PropTypes.func,
+  tabIndex: PropTypes.number,
+  field: PropTypes.object,
+  errors: PropTypes.object,
+  alerts: PropTypes.object,
+  renderer: PropTypes.func
+}
+
+export default MultipickerField

--- a/components/form/builder/src/Standard/index.js
+++ b/components/form/builder/src/Standard/index.js
@@ -6,7 +6,8 @@ const FIELDS = {
   TEXT: 'text',
   NUMERIC: 'numeric',
   FIELDSET: 'fieldset',
-  PICKER: 'picker'
+  PICKER: 'picker',
+  MULTIPICKER: 'multipicker'
 }
 
 const DISPLAYS = {


### PR DESCRIPTION
Add display `multipicker` value.

Given a field like:
```js
export const householdsExtrasField = {
  id: FIELD_KEYS.HOUSEHOLDS_EXTRAS,
  type: 'multipicker',
  label: 'Extras',
  value: [],
  datalist: [
    {value: '1', text: 'Ascensor'},
    {value: '2', text: 'Garaje'},
    {value: '16', text: 'Terraza'},
    {value: '32', text: 'Calefacción'},
    {value: '64', text: 'Piscina'},
    {value: '128', text: 'Jardin'},
    {value: '4', text: 'Amueblado'},
    {value: '8', text: 'Trastero'}
  ]
}
```

It will render:

![image](https://user-images.githubusercontent.com/32937662/97984371-fd9c0700-1dd6-11eb-8c8d-a02203ad1521.png)
