### PR TITLE
Feature/tcf resurface

### DIFF
--- a/components/tcf/services/src/infrastructure/tcf/factory.js
+++ b/components/tcf/services/src/infrastructure/tcf/factory.js
@@ -2,6 +2,6 @@ import {TcfRepository} from './TcfRepository'
 import TcfApiInitializer from '@adv-ui/boros-tcf'
 
 export function tcfRepositoryFactory({language, reporter, scope}) {
-  const tcfApi = TcfApiInitializer.init({language, reporter})
+  const tcfApi = TcfApiInitializer.init({language, reporter, scope})
   return new TcfRepository({tcfApi, scope})
 }

--- a/components/tcf/ui/src/index.js
+++ b/components/tcf/ui/src/index.js
@@ -12,7 +12,10 @@ const CONSENT_SCOPE = {
   purposes: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
   specialPurposes: [1, 2],
   features: [3],
-  specialFeatures: [1]
+  specialFeatures: [1],
+  options: {
+    onRejectionResurfaceAfterDays: 1
+  }
 }
 
 export default function TcfUi({


### PR DESCRIPTION
This enables resurfacing the TCF UI after 1 day if an user has rejected any purpose/specialFeature in order to request the user to revalidate the consent.

**Detailed info**: https://github.com/scm-spain/boros-tcf/pull/51

To validate this behavior locally:
`npm run dev tcf/ui -- --link-package=components/tcf/services --link-package=../boros-tcf`
