### PR TITLE
feat(form/builder): add new prop useNativeFieldType to form builder

### DIFF
--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -7,6 +7,7 @@ import {RULES} from './reducer/constants'
 import {
   pickFieldById,
   fieldsToObject,
+  fieldsToObjectNativeTypes,
   fieldsNamesInOrderOfDefinition,
   changeFieldById
 } from './reducer/fields'
@@ -28,6 +29,7 @@ const FormBuilder = ({
   alerts,
   transformations,
   locale,
+  useNativeFieldType = false,
   children: renderer
 }) => {
   const {fields = [], rules = {}, id: formID} = json.form
@@ -70,8 +72,11 @@ const FormBuilder = ({
 
     clearTimeout(timerShowSpinner)
     setStateFields(nextStateFields)
+    const nextStateFieldsObject = useNativeFieldType
+      ? fieldsToObjectNativeTypes(nextStateFields)
+      : fieldsToObject(nextStateFields)
     onChange({
-      ...fieldsToObject(nextStateFields),
+      ...nextStateFieldsObject,
       __FIELD_CHANGED__: id
     })
     setStateShowSpinner(false)
@@ -150,6 +155,7 @@ FormBuilder.propTypes = {
   alerts: PropTypes.object,
   transformations: PropTypes.func,
   locale: PropTypes.string,
+  useNativeFieldType: PropTypes.bool,
   children: PropTypes.func
 }
 

--- a/components/form/builder/src/reducer/fields.js
+++ b/components/form/builder/src/reducer/fields.js
@@ -28,6 +28,30 @@ export const fieldsToArrayOfString = fields => {
     return `${id}=${value}`
   })
 }
+export const fieldsToArrayOfArray = fields => {
+  return Object.entries(fieldsToObject(fields))
+}
+
+export const fieldsToObjectNativeTypes = fields => {
+  const listFields = deepFlatten(
+    fields.map(field => {
+      if (field.fields) {
+        return fieldsToArrayOfArray(field.fields).map(field => {
+          const [id, value] = field
+          return {[id]: value || ''}
+        })
+      }
+
+      return {[field.id]: field.value || ''}
+    })
+  ).reduce((acc, field) => {
+    const [id, value] = head(Object.entries(field))
+    acc[id] = value
+    return acc
+  }, {})
+
+  return listFields
+}
 
 export const fieldsToObject = fields => {
   const listFields = deepFlatten(


### PR DESCRIPTION
#### Changes

Add a new prop `useNativeFieldType`
- (default) If false returns all fields as string
- if true returns the native value of the field.

#### Example
If we have a form with images and we console.log the fields returned when : `useNativeFieldType: false`
![image](https://user-images.githubusercontent.com/32937662/99971454-76bac880-2d9d-11eb-9540-8cf8278a0f45.png)

If we have a form with images and we console.log the fields returned when : `useNativeFieldType: true`
![image](https://user-images.githubusercontent.com/32937662/99971400-6571bc00-2d9d-11eb-8142-4b797c8ac061.png)

With this change we can receive fields that are non strings like the media field in the captures. It also applies to numbers, or other kind of fields.

#### Compatibility
It is NOT a breaking change