### PR TITLE
feat(tcf/ui): reserve the space for logo to improve CSL

### DIFF
--- a/components/tcf/ui/src/FirstLayer/index.scss
+++ b/components/tcf/ui/src/FirstLayer/index.scss
@@ -88,6 +88,7 @@ $base-class-modal: '#sui-TcfFirstLayerModal';
   &-logo {
     max-width: $maw-tcf-first-layer-logo;
     height: $h-tcf-first-layer-logo;
+    object-fit: contain;
   }
 
   .sui-MoleculeNotification-iconLeft {

--- a/components/tcf/ui/src/FirstLayer/index.scss
+++ b/components/tcf/ui/src/FirstLayer/index.scss
@@ -13,6 +13,7 @@ $fz-tcf-first-layer-title: $fz-h5 !default; //18px
 $h-tcf-first-layer-footer: 88px;
 $maw-tcf-first-layer-buttons: 200px + $p-xxxl !default;
 $maw-tcf-first-layer-logo: 114px !default;
+$h-tcf-first-layer-logo: 22px !default;
 $maw-tcf-first-layer: 1200px !default;
 $p-tcf-first-layer-buttons--desktop: 24px 33px;
 $p-tcf-first-layer-buttons--mobile: 24px 0px;
@@ -85,7 +86,8 @@ $base-class-modal: '#sui-TcfFirstLayerModal';
   }
 
   &-logo {
-    width: $maw-tcf-first-layer-logo;
+    max-width: $maw-tcf-first-layer-logo;
+    height: $h-tcf-first-layer-logo;
   }
 
   .sui-MoleculeNotification-iconLeft {


### PR DESCRIPTION
## Description
Due not reserving height for logo the metric of Cumulative Shift Layout could be affected.

![Screen Recording 2020-11-18 at 13 53 25](https://user-images.githubusercontent.com/45286922/100451699-2652ac00-30b8-11eb-966a-ca40d84c7324.gif)

This PR reserve the height of the logo to present the jump in the header.

## Solves ticket
https://jira.scmspain.com/browse/PSP-3704

## Screenshots
### Minimal changes in aspect in FC, CN, MN and MA
**Before**
![Screenshot 2020-11-27 at 13 59 16](https://user-images.githubusercontent.com/45286922/100452091-c577a380-30b8-11eb-95d3-425fdea01eff.png)

**After**
|![Screenshot 2020-11-27 at 13 46 53](https://user-images.githubusercontent.com/45286922/100451938-81849e80-30b8-11eb-8b15-ffb581770069.png)

### Significative changes in IJ
**Before**
![Screenshot 2020-11-27 at 13 47 47](https://user-images.githubusercontent.com/45286922/100452181-eb9d4380-30b8-11eb-8859-f1371dbe069b.png)

**After**
![Screenshot 2020-11-27 at 13 47 00](https://user-images.githubusercontent.com/45286922/100452201-f22bbb00-30b8-11eb-9ae7-332b2c90a371.png)
