### PR TITLE
fix(topbar/user): prevent unlock scroll on desktop

### DIFF
--- a/components/map/basic/src/index.js
+++ b/components/map/basic/src/index.js
@@ -335,5 +335,5 @@ MapBasic.defaultProps = {
 
 MapBasic.displayName = 'MapBasic'
 
-export default MapBasic
 export {mapLanguages}
+export default MapBasic

--- a/components/topbar/user/src/index.js
+++ b/components/topbar/user/src/index.js
@@ -112,7 +112,6 @@ export default function TopbarUser({
 
   useEffect(() => {
     let _verticalScrollPosition
-
     /**
      * Lock body element scroll.
      */
@@ -142,7 +141,11 @@ export default function TopbarUser({
         window.scrollTo(0, _verticalScrollPosition)
     }
 
-    if (menuExpanded && !isToggleHidden) {
+    // Given toggle button is hidden in desktop.
+    // Then we must not lock/unlock body there
+    if (isToggleHidden) return
+
+    if (menuExpanded) {
       _lockBodyScroll()
     } else {
       _unlockBodyScroll()


### PR DESCRIPTION
In desktop, each re-render makes we unlock scroll. Unlock scroll makes a scrollTop. So each re-render we scrollTop
It is an issue for product