### PR TITLE
Feature/full consent when bots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 .env
 .DS_Store
 components/package.json
+.idea/

--- a/components/tcf/services/src/application/Service.js
+++ b/components/tcf/services/src/application/Service.js
@@ -1,22 +1,24 @@
-class Service {
+export class Service {
   constructor({
     getVendorListUseCase,
     loadConsentDraftUseCase,
     loadUserConsentUseCase,
+    saveFullUserConsentUseCase,
     saveUserConsentUseCase,
+    uiVisibleUseCase,
     updateConsentPurposeUseCase,
     updateConsentSpecialFeatureUseCase,
-    updateConsentVendorUseCase,
-    uiVisibleUseCase
+    updateConsentVendorUseCase
   }) {
     this._getVendorListUseCase = getVendorListUseCase
     this._loadConsentDraftUseCase = loadConsentDraftUseCase
     this._loadUserConsentUseCase = loadUserConsentUseCase
+    this._saveFullUserConsentUserCase = saveFullUserConsentUseCase
     this._saveUserConsentUseCase = saveUserConsentUseCase
+    this._uiVisibleUseCase = uiVisibleUseCase
     this._updateConsentPurposeUseCase = updateConsentPurposeUseCase
     this._updateConsentSpecialFeatureUseCase = updateConsentSpecialFeatureUseCase
     this._updateConsentVendorUseCase = updateConsentVendorUseCase
-    this._uiVisibleUseCase = uiVisibleUseCase
   }
 
   getVendorList() {
@@ -33,6 +35,10 @@ class Service {
 
   saveUserConsent() {
     return this._saveUserConsentUseCase.execute()
+  }
+
+  saveFullUserConsent() {
+    return this._saveFullUserConsentUserCase.execute()
   }
 
   updatePurpose({id, consent}) {
@@ -61,5 +67,3 @@ class Service {
     return this._uiVisibleUseCase.execute({visible})
   }
 }
-
-export {Service}

--- a/components/tcf/services/src/application/service/SaveFullUserConsentUseCase.js
+++ b/components/tcf/services/src/application/service/SaveFullUserConsentUseCase.js
@@ -1,0 +1,11 @@
+export class SaveFullUserConsentUseCase {
+  constructor({repository}) {
+    this._repository = repository
+  }
+
+  execute() {
+    const fullConsent = this._repository.loadFullUserConsent()
+    const userConsent = fullConsent.asUserConsent()
+    return this._repository.saveUserConsent(userConsent)
+  }
+}

--- a/components/tcf/services/src/application/service/factory.js
+++ b/components/tcf/services/src/application/service/factory.js
@@ -6,6 +6,7 @@ import {UiVisibleUseCase} from './UiVisibleUseCase'
 import {UpdateConsentPurposeUseCase} from './UpdateConsentPurposeUseCase'
 import {UpdateConsentSpecialFeatureUseCase} from './UpdateConsentSpecialFeatureUseCase'
 import {UpdateConsentVendorUseCase} from './UpdateConsentVendorUseCase'
+import {SaveFullUserConsentUseCase} from './SaveFullUserConsentUseCase'
 
 export function getVendorListUseCaseFactory({repository}) {
   return new GetVendorListUseCase({
@@ -47,4 +48,8 @@ export function updateConsentSpecialFeatureUseCaseFactory({repository}) {
 
 export function updateConsentVendorUseCaseFactory({repository}) {
   return new UpdateConsentVendorUseCase({repository})
+}
+
+export function saveFullUserConsentUseCaseFactory({repository}) {
+  return new SaveFullUserConsentUseCase({repository})
 }

--- a/components/tcf/services/src/domain/FullConsent.js
+++ b/components/tcf/services/src/domain/FullConsent.js
@@ -1,0 +1,44 @@
+import {ConsentDraft} from './ConsentDraft'
+
+export class FullConsent extends ConsentDraft {
+  /**
+   * @param scope {import('./Scope.d.ts').Scope}
+   */
+  constructor({scope = {}} = {}) {
+    const purpose = {consents: {}, legitimateInterests: {1: false}}
+    const {
+      purposes: scopedPurposes,
+      specialFeatures: scopedSpecialFeatures,
+      interestConsentVendors: scopedInterestConsentVendors
+    } = scope
+    scopedPurposes &&
+      scopedPurposes.forEach(
+        scopedPurpose => (purpose.consents[scopedPurpose] = true)
+      )
+    scopedPurposes &&
+      scopedPurposes
+        .filter(purpose => purpose > 1)
+        .forEach(
+          scopedPurpose => (purpose.legitimateInterests[scopedPurpose] = true)
+        )
+    const specialFeatures = {}
+    scopedSpecialFeatures &&
+      scopedSpecialFeatures.forEach(
+        specialFeature => (specialFeatures[specialFeature] = true)
+      )
+    const vendor = {consents: {}, legitimateInterests: {}}
+    scopedInterestConsentVendors &&
+      scopedInterestConsentVendors.forEach(interestConsentVendor => {
+        vendor.consents[interestConsentVendor] = true
+        vendor.legitimateInterests[interestConsentVendor] = true
+      })
+    super({
+      scope,
+      purpose,
+      vendor,
+      specialFeatures,
+      valid: true,
+      vendorTouched: false
+    })
+  }
+}

--- a/components/tcf/services/src/domain/Scope.d.ts
+++ b/components/tcf/services/src/domain/Scope.d.ts
@@ -1,0 +1,5 @@
+export type Scope = {
+  purposes: number[],
+  specialFeatures: number[],
+  interestConsentVendors: number[]
+}

--- a/components/tcf/services/src/index.js
+++ b/components/tcf/services/src/index.js
@@ -7,10 +7,14 @@ import {eventReporterFactory} from './infrastructure/reporter/eventReporter'
 import {TCF_CONTEXT_INITIALIZED} from './core/events'
 
 function ConsentProvider({language, isMobile, reporter, scope, children}) {
-  const eventReporter = useRef(eventReporterFactory(reporter))
-  const service = useRef(
+  const eventReporter = useRef()
+  eventReporter.current =
+    eventReporter.current || eventReporterFactory(reporter)
+  const service = useRef()
+  service.current =
+    service.current ||
     ServiceInitializer.init({language, reporter: eventReporter.current, scope})
-  )
+
   const loadConsentDraft = () => service.current.loadConsentDraft()
   const loadUserConsent = () => service.current.loadUserConsent()
   const getVendorList = () => service.current.getVendorList()
@@ -24,6 +28,7 @@ function ConsentProvider({language, isMobile, reporter, scope, children}) {
         }))
     )
   const saveUserConsent = () => service.current.saveUserConsent()
+  const saveFullUserConsent = () => service.current.saveFullUserConsent()
   const updatePurpose = ({id, consent}) =>
     service.current.updatePurpose({id, consent})
   const updateSpecialFeature = ({id, consent}) =>
@@ -35,22 +40,22 @@ function ConsentProvider({language, isMobile, reporter, scope, children}) {
   useEffect(() => {
     eventReporter.current(TCF_CONTEXT_INITIALIZED, {language, isMobile})
   })
-
   return (
     <ConsentContext.Provider
       value={{
-        language,
+        getScope,
+        getVendorList,
         isMobile,
-        reporter: eventReporter.current,
+        language,
         loadConsentDraft,
         loadUserConsent,
-        getVendorList,
-        getScope,
+        reporter: eventReporter.current,
+        saveFullUserConsent,
         saveUserConsent,
+        uiVisible,
         updatePurpose,
         updateSpecialFeature,
-        updateVendor,
-        uiVisible
+        updateVendor
       }}
     >
       {children}

--- a/components/tcf/services/src/infrastructure/bootstrap/ServiceInitializer.js
+++ b/components/tcf/services/src/infrastructure/bootstrap/ServiceInitializer.js
@@ -1,20 +1,24 @@
 import {Service} from '../../application/Service'
 import {
-  saveUserConsentUseCaseFactory,
-  loadUserConsentUseCaseFactory,
   getVendorListUseCaseFactory,
+  loadConsentDraftUseCaseFactory,
+  loadUserConsentUseCaseFactory,
+  saveFullUserConsentUseCaseFactory,
+  saveUserConsentUseCaseFactory,
   uiVisibleUseCaseFactory,
   updateConsentPurposeUseCaseFactory,
   updateConsentSpecialFeatureUseCaseFactory,
-  updateConsentVendorUseCaseFactory,
-  loadConsentDraftUseCaseFactory
+  updateConsentVendorUseCaseFactory
 } from '../../application/service/factory'
 import {tcfRepositoryFactory} from '../tcf/factory'
 
-class ServiceInitializer {
+export class ServiceInitializer {
   static init({language, reporter, scope} = {}) {
     const tcfRepository = tcfRepositoryFactory({language, reporter, scope})
     const saveUserConsentUseCase = saveUserConsentUseCaseFactory({
+      repository: tcfRepository
+    })
+    const saveFullUserConsentUseCase = saveFullUserConsentUseCaseFactory({
       repository: tcfRepository
     })
     const uiVisibleUseCase = uiVisibleUseCaseFactory({
@@ -41,16 +45,15 @@ class ServiceInitializer {
       repository: tcfRepository
     })
     return new Service({
-      saveUserConsentUseCase,
+      getVendorListUseCase,
       loadConsentDraftUseCase,
       loadUserConsentUseCase,
-      getVendorListUseCase,
+      saveFullUserConsentUseCase,
+      saveUserConsentUseCase,
+      uiVisibleUseCase,
       updateConsentPurposeUseCase,
       updateConsentSpecialFeatureUseCase,
-      updateConsentVendorUseCase,
-      uiVisibleUseCase
+      updateConsentVendorUseCase
     })
   }
 }
-
-export {ServiceInitializer}

--- a/components/tcf/services/src/infrastructure/tcf/TcfRepository.js
+++ b/components/tcf/services/src/infrastructure/tcf/TcfRepository.js
@@ -1,12 +1,14 @@
 import {ConsentDraft} from '../../domain/ConsentDraft'
+import {FullConsent} from '../../domain/FullConsent'
 
-class TcfRepository {
+export class TcfRepository {
   constructor({tcfApi, scope}) {
     this._tcfApi = tcfApi
     this._scope = scope
     this._draft = new ConsentDraft({
       scope: this._scope
     })
+    this._fullUserConsent = new FullConsent({scope: this._scope})
   }
 
   getVendorList() {
@@ -19,6 +21,10 @@ class TcfRepository {
 
   loadConsentDraft() {
     return this._draft
+  }
+
+  loadFullUserConsent() {
+    return this._fullUserConsent
   }
 
   initConsentDraft({userConsent}) {
@@ -37,5 +43,3 @@ class TcfRepository {
     return this._tcfApi.uiVisible({visible})
   }
 }
-
-export {TcfRepository}

--- a/components/tcf/ui/src/TCFContainer/isBotService.js
+++ b/components/tcf/ui/src/TCFContainer/isBotService.js
@@ -1,0 +1,18 @@
+const BOTS_USER_AGENTS = [
+  'googlebot',
+  'google-structured-data-testing-tool',
+  'bingbot',
+  'linkedinbot',
+  'mediapartners-google',
+  'apis-google',
+  'adsbot-google-mobile',
+  'adsbot-google',
+  'googlebot-image',
+  'googlebot-news',
+  'googlebot-video',
+  'adsbot-google-mobile-apps'
+]
+
+export default function isBotService({userAgent}) {
+  return BOTS_USER_AGENTS.some(ua => userAgent.toLowerCase().includes(ua))
+}

--- a/test/tcf/services/application/service/saveFullUserConsentUseCase.test.js
+++ b/test/tcf/services/application/service/saveFullUserConsentUseCase.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+import {SaveFullUserConsentUseCase} from '../../../../../components/tcf/services/src/application/service/SaveFullUserConsentUseCase'
+import {FullConsent} from '../../../../../components/tcf/services/src/domain/FullConsent'
+
+describe('SaveFullUserConsentUseCase', function() {
+  it('should save full accepted user consent', () => {
+    const givenFullConsent = new FullConsent()
+    const expectedConsent = givenFullConsent.asUserConsent()
+
+    const mockRepository = {
+      loadFullUserConsent: () => givenFullConsent,
+      saveUserConsent: () => expectedConsent
+    }
+    const spyLoadFullUserConsent = jest.spyOn(
+      mockRepository,
+      'loadFullUserConsent'
+    )
+    const spySaveUserConsent = jest.spyOn(mockRepository, 'saveUserConsent')
+    const saveFullUserConsentUseCase = new SaveFullUserConsentUseCase({
+      repository: mockRepository
+    })
+    const response = saveFullUserConsentUseCase.execute()
+    expect(response).toBe(expectedConsent)
+    expect(spyLoadFullUserConsent).toHaveBeenCalledTimes(1)
+    expect(spySaveUserConsent).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Description

This PR prevents the modal to be displayed if the "user" is a crawler or a bot. This modification increases SEO and crawling time and was tested successfully in MA.

## Solves tickets
https://jira.scmspain.com/browse/PSP-3746

## Review steps
You can manually review with the demo of tcf/ui linked with tcf/services and changing the userAgent in the devtools with ```Mozilla/5.0 (Linux; Android 5.0; SM-G920A) AppleWebKit (KHTML, like Gecko) Chrome Mobile Safari (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)```
