### PR TITLE
feat(image/lazyLoad): add onError handling functionality...

### DIFF
--- a/components/image/lazyLoad/src/index.js
+++ b/components/image/lazyLoad/src/index.js
@@ -12,6 +12,7 @@ export default function ImageLazyLoad({
   alt = '',
   title = '',
   aspectRatio = '',
+  onError = () => {},
   offsetVertical = 100,
   showSpinner = true,
   src
@@ -32,9 +33,10 @@ export default function ImageLazyLoad({
       <div className={`${BASE_CLASS}-imageWrap`}>
         {isNearScreen && (
           <img
-            className={`${BASE_CLASS}-image`}
-            src={src}
             alt={alt}
+            className={`${BASE_CLASS}-image`}
+            onError={onError}
+            src={src}
             title={title}
           />
         )}
@@ -44,6 +46,10 @@ export default function ImageLazyLoad({
 }
 
 ImageLazyLoad.propTypes = {
+  /**
+   * Specify how to handle, can be useful to specify a fallback image.
+   */
+  onError: PropTypes.func,
   /**
    * This option allows you to specify how far above and below the viewport you
    * want to begin displaying your content.


### PR DESCRIPTION
…to imageLazyLoad component.

It'd be useful for cases where we'd like to specify a fallback / empty case image when the actual src file could not be loaded.

Currently, we see:
![image](https://user-images.githubusercontent.com/18154356/105153345-9bff5500-5b08-11eb-9c10-efccd34a6e1e.png)

When img's onerror is properly handled, we can pass on an empty case image (or do whatever we want to handle the error):
![image](https://user-images.githubusercontent.com/18154356/105153549-dc5ed300-5b08-11eb-8797-a9a6569dda0a.png)

See [Browser support for `img onerror` attribute](https://caniuse.com/mdn-html_elements_img_onerror).