### PR TITLE
Feat: new fitMode prop for image/lazyLoad 

### DIFF
--- a/components/image/lazyLoad/src/index.js
+++ b/components/image/lazyLoad/src/index.js
@@ -22,7 +22,7 @@ export default function ImageLazyLoad({
 
   const lazyLoadWrapClassName = cx(BASE_CLASS, {
     [`${BASE_CLASS}--ratio-${aspectRatio.replace(':', '-')}`]: aspectRatio,
-    [`${BASE_CLASS}--is-contained`]: isContained
+    'is-contained': isContained
   })
   const lazyLoadImageWrapClassName = cx(`${BASE_CLASS}-imageWrap`, {
     [`${BASE_CLASS}-imageWrap--is-contained`]: isContained

--- a/components/image/lazyLoad/src/index.js
+++ b/components/image/lazyLoad/src/index.js
@@ -6,6 +6,14 @@ import {useNearScreen} from '@s-ui/react-hooks'
 const BASE_CLASS = 'sui-ImageLazyLoad'
 const BASE_CLASS_IMAGE = `${BASE_CLASS}-image`
 const BASE_CLASS_IMAGE_WRAP = `${BASE_CLASS}-imageWrap`
+
+export const FIT_MODES = {
+  contain: 'contain',
+  cover: 'cover',
+  default: 'default',
+  fill: 'fill',
+  none: 'none'
+}
 /**
  * Component that will print defer loading images with an optional and specific
  * aspect ratio.
@@ -13,7 +21,7 @@ const BASE_CLASS_IMAGE_WRAP = `${BASE_CLASS}-imageWrap`
 export default function ImageLazyLoad({
   alt = '',
   aspectRatio = '',
-  isContained = false,
+  fitMode = FIT_MODES.default,
   offsetVertical = 100,
   onError = () => {},
   showSpinner = true,
@@ -24,13 +32,22 @@ export default function ImageLazyLoad({
 
   const lazyLoadWrapClassName = cx(BASE_CLASS, {
     [`${BASE_CLASS}--ratio-${aspectRatio.replace(':', '-')}`]: aspectRatio,
-    [`${BASE_CLASS}--is-contained`]: isContained
+    [`${BASE_CLASS}--fitContain`]: fitMode === FIT_MODES.contain,
+    [`${BASE_CLASS}--fitCover`]: fitMode === FIT_MODES.cover,
+    [`${BASE_CLASS}--fitFill`]: fitMode === FIT_MODES.fill,
+    [`${BASE_CLASS}--fitNone`]: fitMode === FIT_MODES.none
   })
   const lazyLoadImageClassName = cx(BASE_CLASS_IMAGE, {
-    [`${BASE_CLASS_IMAGE}--is-contained`]: isContained
+    [`${BASE_CLASS_IMAGE}--fitContain`]: fitMode === FIT_MODES.contain,
+    [`${BASE_CLASS_IMAGE}--fitCover`]: fitMode === FIT_MODES.cover,
+    [`${BASE_CLASS_IMAGE}--fitFill`]: fitMode === FIT_MODES.fill,
+    [`${BASE_CLASS_IMAGE}--fitNone`]: fitMode === FIT_MODES.none
   })
   const lazyLoadImageWrapClassName = cx(BASE_CLASS_IMAGE_WRAP, {
-    [`${BASE_CLASS_IMAGE_WRAP}--is-contained`]: isContained
+    [`${BASE_CLASS_IMAGE_WRAP}--fitContain`]: fitMode === FIT_MODES.contain,
+    [`${BASE_CLASS_IMAGE_WRAP}--fitCover`]: fitMode === FIT_MODES.cover,
+    [`${BASE_CLASS_IMAGE_WRAP}--fitFill`]: fitMode === FIT_MODES.fill,
+    [`${BASE_CLASS_IMAGE_WRAP}--fitNone`]: fitMode === FIT_MODES.none
   })
 
   return (
@@ -57,9 +74,9 @@ export default function ImageLazyLoad({
 
 ImageLazyLoad.propTypes = {
   /**
-   * Flag to apply object-fit: contain to the image.
+   * Specifies which object-fit applies to the image.
    */
-  isContained: PropTypes.bool,
+  fitMode: PropTypes.oneOf(Object.values(FIT_MODES)),
   /**
    * Specify how to handle, can be useful to specify a fallback image.
    */

--- a/components/image/lazyLoad/src/index.js
+++ b/components/image/lazyLoad/src/index.js
@@ -4,6 +4,8 @@ import SpinnerBasic from '@s-ui/react-spinner-basic'
 import {useNearScreen} from '@s-ui/react-hooks'
 
 const BASE_CLASS = 'sui-ImageLazyLoad'
+const BASE_CLASS_IMAGE = `${BASE_CLASS}-image`
+const BASE_CLASS_IMAGE_WRAP = `${BASE_CLASS}-imageWrap`
 /**
  * Component that will print defer loading images with an optional and specific
  * aspect ratio.
@@ -22,13 +24,13 @@ export default function ImageLazyLoad({
 
   const lazyLoadWrapClassName = cx(BASE_CLASS, {
     [`${BASE_CLASS}--ratio-${aspectRatio.replace(':', '-')}`]: aspectRatio,
-    'is-contained': isContained
+    [`${BASE_CLASS}--is-contained`]: isContained
   })
-  const lazyLoadImageWrapClassName = cx(`${BASE_CLASS}-imageWrap`, {
-    'is-contained': isContained
+  const lazyLoadImageClassName = cx(BASE_CLASS_IMAGE, {
+    [`${BASE_CLASS_IMAGE}--is-contained`]: isContained
   })
-  const lazyLoadImageClassName = cx(`${BASE_CLASS}-image`, {
-    'is-contained': isContained
+  const lazyLoadImageWrapClassName = cx(BASE_CLASS_IMAGE_WRAP, {
+    [`${BASE_CLASS_IMAGE_WRAP}--is-contained`]: isContained
   })
 
   return (

--- a/components/image/lazyLoad/src/index.js
+++ b/components/image/lazyLoad/src/index.js
@@ -25,7 +25,7 @@ export default function ImageLazyLoad({
     'is-contained': isContained
   })
   const lazyLoadImageWrapClassName = cx(`${BASE_CLASS}-imageWrap`, {
-    [`${BASE_CLASS}-imageWrap--is-contained`]: isContained
+    'is-contained': isContained
   })
   const lazyLoadImageClassName = cx(`${BASE_CLASS}-image`, {
     [`${BASE_CLASS}-image--is-contained`]: isContained

--- a/components/image/lazyLoad/src/index.js
+++ b/components/image/lazyLoad/src/index.js
@@ -28,7 +28,7 @@ export default function ImageLazyLoad({
     'is-contained': isContained
   })
   const lazyLoadImageClassName = cx(`${BASE_CLASS}-image`, {
-    [`${BASE_CLASS}-image--is-contained`]: isContained
+    'is-contained': isContained
   })
 
   return (

--- a/components/image/lazyLoad/src/index.js
+++ b/components/image/lazyLoad/src/index.js
@@ -10,17 +10,25 @@ const BASE_CLASS = 'sui-ImageLazyLoad'
  */
 export default function ImageLazyLoad({
   alt = '',
-  title = '',
   aspectRatio = '',
-  onError = () => {},
+  isContained = false,
   offsetVertical = 100,
+  onError = () => {},
   showSpinner = true,
-  src
+  src,
+  title = ''
 }) {
   const [isNearScreen, fromRef] = useNearScreen({offset: `${offsetVertical}px`})
 
   const lazyLoadWrapClassName = cx(BASE_CLASS, {
-    [`${BASE_CLASS}--ratio-${aspectRatio.replace(':', '-')}`]: aspectRatio
+    [`${BASE_CLASS}--ratio-${aspectRatio.replace(':', '-')}`]: aspectRatio,
+    [`${BASE_CLASS}--is-contained`]: isContained
+  })
+  const lazyLoadImageWrapClassName = cx(`${BASE_CLASS}-imageWrap`, {
+    [`${BASE_CLASS}-imageWrap--is-contained`]: isContained
+  })
+  const lazyLoadImageClassName = cx(`${BASE_CLASS}-image`, {
+    [`${BASE_CLASS}-image--is-contained`]: isContained
   })
 
   return (
@@ -30,11 +38,11 @@ export default function ImageLazyLoad({
           <SpinnerBasic />
         </div>
       )}
-      <div className={`${BASE_CLASS}-imageWrap`}>
+      <div className={lazyLoadImageWrapClassName}>
         {isNearScreen && (
           <img
             alt={alt}
-            className={`${BASE_CLASS}-image`}
+            className={lazyLoadImageClassName}
             onError={onError}
             src={src}
             title={title}
@@ -46,6 +54,10 @@ export default function ImageLazyLoad({
 }
 
 ImageLazyLoad.propTypes = {
+  /**
+   * Flag to apply object-fit: contain to the image.
+   */
+  isContained: PropTypes.bool,
   /**
    * Specify how to handle, can be useful to specify a fallback image.
    */

--- a/components/image/lazyLoad/src/index.scss
+++ b/components/image/lazyLoad/src/index.scss
@@ -64,7 +64,9 @@ $aspect-ratios: (
     width: 100%;
   }
 
-  .is-contained {
+  &--is-contained,
+  &-image--is-contained,
+  &-imageWrap--is-contained {
     height: 100%;
     width: 100%;
     object-fit: contain;

--- a/components/image/lazyLoad/src/index.scss
+++ b/components/image/lazyLoad/src/index.scss
@@ -64,9 +64,7 @@ $aspect-ratios: (
     width: 100%;
   }
 
-  &--is-contained,
-  &-image--is-contained,
-  &-imageWrap--is-contained {
+  .is-contained {
     height: 100%;
     width: 100%;
     object-fit: contain;

--- a/components/image/lazyLoad/src/index.scss
+++ b/components/image/lazyLoad/src/index.scss
@@ -64,12 +64,44 @@ $aspect-ratios: (
     width: 100%;
   }
 
-  &--is-contained,
-  &-image--is-contained,
-  &-imageWrap--is-contained {
+  &--fitContain,
+  &-image--fitContain,
+  &-imageWrap--fitContain,
+  &--fitCover,
+  &-image--fitCover,
+  &-imageWrap--fitCover,
+  &--fitFill,
+  &-image--fitFill,
+  &-imageWrap--fitFill,
+  &--fitNone,
+  &-image--fitNone,
+  &-imageWrap--fitNone {
     height: 100%;
     width: 100%;
+  }
+
+  &--fitContain,
+  &-image--fitContain,
+  &-imageWrap--fitContain {
     object-fit: contain;
+  }
+
+  &--fitCover,
+  &-image--fitCover,
+  &-imageWrap--fitCover {
+    object-fit: cover;
+  }
+
+  &--fitFill,
+  &-image--fitFill,
+  &-imageWrap--fitFill {
+    object-fit: fill;
+  }
+
+  &--fitNone,
+  &-image--fitNone,
+  &-imageWrap--fitNone {
+    object-fit: none;
   }
 
   .LazyLoad {

--- a/components/image/lazyLoad/src/index.scss
+++ b/components/image/lazyLoad/src/index.scss
@@ -64,6 +64,14 @@ $aspect-ratios: (
     width: 100%;
   }
 
+  &--is-contained,
+  &-image--is-contained,
+  &-imageWrap--is-contained {
+    height: 100%;
+    width: 100%;
+    object-fit: contain;
+  }
+
   .LazyLoad {
     align-items: center;
     display: flex;

--- a/demo/image/lazyLoad/playground
+++ b/demo/image/lazyLoad/playground
@@ -1,6 +1,6 @@
 /* eslint react/react-in-jsx-scope:0, react/jsx-no-undef:0 */
 return (
-  <div>
+  <div style={{ marginLeft: '20px'}}>
     <h1>Scroll down 👇🏻</h1>
     <div style={{ width: '300px', marginTop: '1000px', marginBottom: '60px' }}>
       <h2>Simple image</h2>
@@ -17,6 +17,18 @@ return (
     <div style={{ width: '300px', marginBottom: '60px' }}>
       <h2>Image with aspect ratio 16:9</h2>
       <ImageLazyLoad aspectRatio='16:9' src='https://picsum.photos/id/1021/200/300' />
+    </div>
+    <div style={{  marginBottom: '60px' }}>
+      <h2>Image contained on a 250x250px container</h2>
+      <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
+        <ImageLazyLoad isContained src='https://picsum.photos/id/1021/400/300' />
+      </div>
+    </div>    
+    <div style={{ marginBottom: '60px' }}>
+      <h2>Image contained on a 250x250px container</h2>
+      <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
+        <ImageLazyLoad isContained src='https://picsum.photos/id/1021/300/400' />
+      </div>
     </div>
   </div>
 )

--- a/demo/image/lazyLoad/playground
+++ b/demo/image/lazyLoad/playground
@@ -19,15 +19,51 @@ return (
       <ImageLazyLoad aspectRatio='16:9' src='https://picsum.photos/id/1021/200/300' />
     </div>
     <div style={{  marginBottom: '60px' }}>
-      <h2>Image contained on a 250x250px container</h2>
+      <h2>400x300px Image with fitMode="contain" on a 250x250px container</h2>
       <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
-        <ImageLazyLoad isContained src='https://picsum.photos/id/1021/400/300' />
+        <ImageLazyLoad fitMode="contain" src='https://picsum.photos/id/1021/400/300' />
       </div>
     </div>    
     <div style={{ marginBottom: '60px' }}>
-      <h2>Image contained on a 250x250px container</h2>
+      <h2>300x400px Image with fitMode="contain" on a 250x250px container</h2>
       <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
-        <ImageLazyLoad isContained src='https://picsum.photos/id/1021/300/400' />
+        <ImageLazyLoad fitMode="contain" src='https://picsum.photos/id/1021/300/400' />
+      </div>
+    </div>
+    <div style={{  marginBottom: '60px' }}>
+      <h2>400x300px Image with fitMode="cover" on a 250x250px container</h2>
+      <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
+        <ImageLazyLoad fitMode="cover" src='https://picsum.photos/id/1021/400/300' />
+      </div>
+    </div>    
+    <div style={{ marginBottom: '60px' }}>
+      <h2>300x400px Image with fitMode="cover" on a 250x250px container</h2>
+      <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
+        <ImageLazyLoad fitMode="cover" src='https://picsum.photos/id/1021/300/400' />
+      </div>
+    </div>
+    <div style={{  marginBottom: '60px' }}>
+      <h2>400x300px Image with fitMode="fill" on a 250x250px container</h2>
+      <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
+        <ImageLazyLoad fitMode="fill" src='https://picsum.photos/id/1021/400/300' />
+      </div>
+    </div>    
+    <div style={{ marginBottom: '60px' }}>
+      <h2>300x400px Image with fitMode="fill" on a 250x250px container</h2>
+      <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
+        <ImageLazyLoad fitMode="fill" src='https://picsum.photos/id/1021/300/400' />
+      </div>
+    </div>
+    <div style={{  marginBottom: '60px' }}>
+      <h2>400x300px Image with fitMode="none" on a 250x250px container</h2>
+      <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
+        <ImageLazyLoad fitMode="none" src='https://picsum.photos/id/1021/400/300' />
+      </div>
+    </div>    
+    <div style={{ marginBottom: '60px' }}>
+      <h2>300x400px Image with fitMode="none" on a 250x250px container</h2>
+      <div style={{backgroundColor: 'white',height: '250px', width: '250px'}}>
+        <ImageLazyLoad fitMode="none" src='https://picsum.photos/id/1021/300/400' />
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adds this backwards compatible prop `fitMode` to the image/lazyLoad component.

`fitMode` refers to the `object-fit` CSS property that will be used and can be one of the following: `contain`, `cover`, `fill`, `none`. Defaults to `default` which is of no real CSS use. 

![image](https://user-images.githubusercontent.com/18154356/105883309-00d61600-6007-11eb-9f3a-930734bd020e.png)
