### PR TITLE
fix(form/builder): Encode remote url

### DIFF
--- a/components/form/builder/src/reducer/fields.js
+++ b/components/form/builder/src/reducer/fields.js
@@ -28,6 +28,14 @@ export const fieldsToArrayOfString = fields => {
     return `${id}=${value}`
   })
 }
+
+export const fieldsToArrayOfStringEncoded = fields => {
+  return Object.entries(fieldsToObject(fields)).map(field => {
+    const [id, value] = field
+    return `${encodeURIComponent(id)}=${encodeURIComponent(value)}`
+  })
+}
+
 export const fieldsToArrayOfArray = fields => {
   return Object.entries(fieldsToObject(fields))
 }
@@ -87,7 +95,9 @@ export const fieldsNamesInOrderOfDefinition = fields => {
 }
 
 export const fieldsToQP = (fields, formID) => {
-  const qs = `form_id=${formID}&${fieldsToArrayOfString(fields).join('&')}`
+  const qs = `form_id=${formID}&${fieldsToArrayOfStringEncoded(fields).join(
+    '&'
+  )}`
   return qs
 }
 

--- a/components/form/builder/src/reducer/rules.js
+++ b/components/form/builder/src/reducer/rules.js
@@ -94,10 +94,12 @@ export const fetchRemoteFields = (
     Object.entries(fieldsToChanges)
       .filter(([field, nextValue]) => nextValue.remote === REMOTE)
       .map(async ([field, nextValue]) => {
-        const defaultUrl = `https://ptaformbuilder-classifiedads.spain.advgo.net/fieldrules/${field}?${fieldsToQP(
-          fields,
-          formID
-        )}`
+        const defaultUrl = encodeURI(
+          `https://ptaformbuilder-classifiedads.spain.advgo.net/fieldrules/${field}?${fieldsToQP(
+            fields,
+            formID
+          )}`
+        )
 
         const defaultConfig = {url: defaultUrl}
 


### PR DESCRIPTION
When fetching remote fields, url should be encoded properly:

- Query String should be encoded using encodeURIComponent
- URL should be encoded using encodeURI

