### PR TITLE
chore(Root): auto order dependencies

### DIFF
--- a/components/ad/smartbanner/package.json
+++ b/components/ad/smartbanner/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-icons": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-icons": "1"
   }
 }

--- a/components/card/article/package.json
+++ b/components/card/article/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-image-lazy-load": "1",
-    "@s-ui/react-icons": "1",
+    "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-tag": "2",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/react-icons": "1",
+    "@s-ui/react-image-lazy-load": "1"
   }
 }

--- a/components/card/basic/package.json
+++ b/components/card/basic/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-image-lazy-load": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-image-lazy-load": "1"
   }
 }

--- a/components/card/product/package.json
+++ b/components/card/product/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@s-ui/component-dependencies": "1",
     "@s-ui/react-icons": "1",
     "@s-ui/react-tag-chip": "1",
-    "@s-ui/component-dependencies": "1",
     "swiper": "3.4.1"
   }
 }

--- a/components/card/subscription/package.json
+++ b/components/card/subscription/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@s-ui/component-dependencies": "1",
     "@s-ui/react-form-checkbox": "1",
-    "@s-ui/react-icons": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/react-icons": "1"
   }
 }

--- a/components/cmp/banner/package.json
+++ b/components/cmp/banner/package.json
@@ -10,10 +10,10 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@s-ui/react-molecule-notification": "1",
     "@s-ui/react-cmp-modal": "1",
     "@s-ui/react-cmp-services": "1",
-    "@s-ui/react-hooks": "1"
+    "@s-ui/react-hooks": "1",
+    "@s-ui/react-molecule-notification": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/cmp/services/package.json
+++ b/components/cmp/services/package.json
@@ -10,9 +10,9 @@
     "test": "sui-test browser"
   },
   "dependencies": {
-    "consent-string": "1.4.2",
+    "@adv-ui/boros-cmp": "2",
     "@s-ui/component-dependencies": "1",
-    "@adv-ui/boros-cmp": "2"
+    "consent-string": "1.4.2"
   },
   "keywords": [],
   "author": "",

--- a/components/cmp/ui/package.json
+++ b/components/cmp/ui/package.json
@@ -12,10 +12,10 @@
     "@s-ui/component-dependencies": "1",
     "@s-ui/js": "2",
     "@s-ui/react-atom-button": "1",
-    "@s-ui/react-molecule-notification": "1",
     "@s-ui/react-cmp-modal": "1",
     "@s-ui/react-cmp-services": "1",
-    "@s-ui/react-hooks": "1"
+    "@s-ui/react-hooks": "1",
+    "@s-ui/react-molecule-notification": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/dropdown/basic/package.json
+++ b/components/dropdown/basic/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-icons": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-icons": "1"
   }
 }

--- a/components/form/checkbox/package.json
+++ b/components/form/checkbox/package.json
@@ -9,8 +9,8 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/react-icons": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-icons": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/form/checkboxesWithParent/package.json
+++ b/components/form/checkboxesWithParent/package.json
@@ -9,9 +9,9 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
+    "@s-ui/component-dependencies": "1",
     "@s-ui/react-form-checkbox": "1",
-    "@s-ui/react-icons": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/react-icons": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/form/rangeDatepicker/package.json
+++ b/components/form/rangeDatepicker/package.json
@@ -12,8 +12,8 @@
     "@s-ui/component-dependencies": "1",
     "@s-ui/react-icons": "1",
     "@schibstedspain/sui-button-basic": "1",
-    "react-datepicker": "1",
-    "moment": "2.20.0"
+    "moment": "2.20.0",
+    "react-datepicker": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/list/tagcloud/package.json
+++ b/components/list/tagcloud/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-tag-chip": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-tag-chip": "1"
   }
 }

--- a/components/modal/basic/package.json
+++ b/components/modal/basic/package.json
@@ -18,7 +18,7 @@
     "react-dom": "16"
   },
   "dependencies": {
-    "@s-ui/react-icons": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-icons": "1"
   }
 }

--- a/components/modal/gallery/package.json
+++ b/components/modal/gallery/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@schibstedspain/sui-image-slider": "2",
-    "@s-ui/react-modal-basic": "1"
+    "@s-ui/react-modal-basic": "1",
+    "@schibstedspain/sui-image-slider": "2"
   },
   "keywords": [],
   "author": "",

--- a/components/tag/chip/package.json
+++ b/components/tag/chip/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-icons": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-icons": "1"
   }
 }

--- a/components/tag/deletableList/package.json
+++ b/components/tag/deletableList/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-tag-chip": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-tag-chip": "1"
   }
 }

--- a/components/tag/selectable/package.json
+++ b/components/tag/selectable/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/react-icons": "1",
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-icons": "1"
   }
 }


### PR DESCRIPTION
Alphabetically order dependencies in some packages where they weren't. This has been done by a `npm run phoenix` automatically.