### PR TITLE
fix(react/hooks): polyfill support for old chrome devices

### DIFF
--- a/components/react/hooks/src/useOnScreen/index.js
+++ b/components/react/hooks/src/useOnScreen/index.js
@@ -26,7 +26,7 @@ export default function useOnScreen({
       'IntersectionObserver' in window &&
       'IntersectionObserverEntry' in window &&
       'intersectionRatio' in window.IntersectionObserverEntry.prototype &&
-      'isIntersecting' in IntersectionObserverEntry.prototype
+      'isIntersecting' in window.IntersectionObserverEntry.prototype
 
     let observer
     ;(isIntersectionObserverEnabled

--- a/components/react/hooks/src/useOnScreen/index.js
+++ b/components/react/hooks/src/useOnScreen/index.js
@@ -20,8 +20,16 @@ export default function useOnScreen({
     const {current} = usableRef || {}
     if (!current) return
 
+    // Some devices support IntersectionObserver API partially so we must check that it is completely supported
+    // See https://github.com/w3c/IntersectionObserver/issues/211
+    const isIntersectionObserverEnabled =
+      'IntersectionObserver' in window &&
+      'IntersectionObserverEntry' in window &&
+      'intersectionRatio' in window.IntersectionObserverEntry.prototype &&
+      'isIntersecting' in IntersectionObserverEntry.prototype
+
     let observer
-    ;(window.IntersectionObserver
+    ;(isIntersectionObserverEnabled
       ? Promise.resolve()
       : import('intersection-observer')
     ).then(() => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  transform: {'.*': '<rootDir>/node_modules/babel-jest'},
   transformIgnorePatterns: [
     '<rootDir>/node_modules/(?!@s-ui/abtesting-toggle/lib/|@babel/runtime)'
   ]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "phoenix:ci": "sui-mono phoenix --no-root --ci && npm run install:demos -- --ci",
     "update:commit:status": "npx @s-ui/ci@1 update-commit-status",
     "start": "sui-studio start",
-    "test": "sui-studio test && npm run test:jest",
+    "test": "npm run test:studio && npm run test:jest",
+    "test:studio": "sui-studio test",
     "test:jest": "jest"
   },
   "repository": {
@@ -28,15 +29,15 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "7.10.4",
+    "@babel/plugin-transform-modules-commonjs": "7.13.0",
     "@s-ui/documentation-library": "1",
     "@s-ui/lint": "3",
     "@s-ui/precommit": "2",
     "@s-ui/studio": "9",
     "enzyme": "3.11.0",
-    "enzyme-adapter-react-16": "1.15.2",
+    "enzyme-adapter-react-16": "1.15.6",
     "husky": "4.3.0",
-    "jest": "24.9.0",
+    "jest": "26.6.3",
     "validate-commit-msg": "2.14.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "sui-studio build",
     "co": "sui-studio commit",
-    "commitmsg": "validate-commit-msg",
     "dev": "sui-studio dev",
     "generate": "sui-studio generate -S s-ui",
     "lint": "npm run lint:js && npm run lint:sass",
@@ -78,6 +77,7 @@
   },
   "husky": {
     "hooks": {
+      "commit-msg": "validate-commit-msg",
       "pre-commit": "sui-precommit run"
     }
   }


### PR DESCRIPTION
This PR fixes an issue for old browser versions that don't support the `IntersectionObserver` API completely so the polyfill must be used (see [issue](https://github.com/w3c/IntersectionObserver/issues/211)).

The condition to check if it was supported was taken from the polyfill.