### PR TITLE
Add null to tcf cookie max age display

### DIFF
--- a/components/tcf/ui/src/SecondLayer/services/secondsToUserReadable.js
+++ b/components/tcf/ui/src/SecondLayer/services/secondsToUserReadable.js
@@ -16,7 +16,7 @@ const secondsToTimeUnits = totalSeconds => {
 }
 
 const userReadable = ({seconds, i18n}) => {
-  if (seconds <= 0) {
+  if (!seconds || seconds <= 0) {
     return i18n.VENDOR_PAGE.GROUPS.EXPANDED.COOKIES.NEGATIVE_OR_ZERO_MAX_AGE
   }
   const time = secondsToTimeUnits(seconds)

--- a/test/tcf/ui/SecondLayer/secondsToUserReadable.test.js
+++ b/test/tcf/ui/SecondLayer/secondsToUserReadable.test.js
@@ -49,8 +49,8 @@ describe('userReadable from Seconds', () => {
     expect(userReadable({seconds: givenSeconds, i18n})).toBe(expected)
   })
 
-  it('should return a fixed string if it`s negative or zero', () => {
-    ;[0, -100].forEach(seconds => {
+  it('should return a fixed string if it`s negative, zero or null', () => {
+    ;[0, -100, null].forEach(seconds => {
       expect(userReadable({seconds, i18n})).toBe(
         i18n.VENDOR_PAGE.GROUPS.EXPANDED.COOKIES.NEGATIVE_OR_ZERO_MAX_AGE
       )


### PR DESCRIPTION
## Description

The IAB vendor list will use null instead of -100 to flag the vendors that doesn't store cookies. This PR adds an additional check when that value is displayed. 

## Solves ticket
https://jira.scmspain.com/browse/PSP-3839