### PR TITLE
feat(perf/dynamicRendering): add chrome-lighthouse user-agent to bot list

### DIFF
--- a/components/perf/dynamicRendering/src/index.js
+++ b/components/perf/dynamicRendering/src/index.js
@@ -7,7 +7,8 @@ const BOTS_USER_AGENTS = [
   'bingbot',
   'linkedinbot',
   'mediapartners-google',
-  'debugbear'
+  'debugbear',
+  'chrome-lighthouse'
 ]
 
 function checkUserAgentIsBot(userAgent, botsUserAgents) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add Chrome-Lighthouse User-Agent in the bot list to ensure that PageSpeed Insight renders the same than Google bot and the rest of the other bots.

https://github.com/GoogleChrome/lighthouse/pull/7297


## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
**Before:**
![image](https://media.github.mpi-internal.com/user/2408/files/01725d00-a687-11eb-83db-710a8c461952)
**After**
![image](https://media.github.mpi-internal.com/user/2408/files/1bac3b00-a687-11eb-8d41-97ae10506ef8)
