### PR TITLE
feat(form/builder): make it async the onChange return callback

### DIFF
--- a/components/form/builder/README.md
+++ b/components/form/builder/README.md
@@ -28,16 +28,16 @@ return <FormBuilder />
 
 ## Update Fields Value Programatically
 
-To update a field programatically you can return an object from the onChange callback, and the key values inside the object will trigger a change in the field.
+To update a field programatically you can return an object from the async onChange callback, and the key values inside the object will trigger a change in the field.
 
 In this example we are chaning the value of the field `color` to `yellow` allways.
 
 ```js
 const onChange = fields => {
     ...
-    return {
+    return Promise.resolve({
         color: 'yellow'
-    }
+    })
 }
 
 <FormBuilder

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -79,7 +79,7 @@ const FormBuilder = ({
     const nextStateFieldsObject = useNativeFieldType
       ? fieldsToObjectNativeTypes(nextStateFields)
       : fieldsToObject(nextStateFields)
-    const fieldsToUpdate = onChange({
+    const fieldsToUpdate = await onChange({
       ...nextStateFieldsObject,
       __FIELD_CHANGED__: id
     })


### PR DESCRIPTION
make it async the onChange return callback. 

This is a breaking change, but since the change was added 2 days ago and nobody is using this callback, a major will not be released and we avoid having to increase the major in all the components that use the form/builder.