### PR TITLE
chore(form/builder): increase major of @s-ui/react-molecule-textarea-field from 2 to 3

### DIFF
--- a/components/form/builder/package.json
+++ b/components/form/builder/package.json
@@ -23,7 +23,7 @@
     "@s-ui/react-molecule-radio-button-field": "1",
     "@s-ui/react-molecule-radio-button-group": "1",
     "@s-ui/react-molecule-select-field": "1",
-    "@s-ui/react-molecule-textarea-field": "2"
+    "@s-ui/react-molecule-textarea-field": "3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Due we need to pass an initial value in MA, we've to increase to the third major to get the latest update about to fix about internalValue and value sync. 