### PR TITLE
feat(image/slider): be able to send custom images to react-slidy

### DIFF
--- a/components/image/slider/src/index.js
+++ b/components/image/slider/src/index.js
@@ -31,7 +31,7 @@ const defaultCounterPatternFactory = ({current, total}) => `${current}/${total}`
  * @return {Array} List of img or node elements.
  */
 const getSlides = (currentSlide, content = [], linkFactory) => {
-  return content.map((content, index) => {
+  return content.map((contentItem, index) => {
     const {
       alt,
       height,
@@ -42,7 +42,7 @@ const getSlides = (currentSlide, content = [], linkFactory) => {
       title,
       type = IMAGE_SLIDER_CONTENT_TYPES.IMAGE,
       width
-    } = content
+    } = contentItem
 
     const key = imageKey ? imageKey + index : index
     const children =
@@ -58,7 +58,7 @@ const getSlides = (currentSlide, content = [], linkFactory) => {
           width={width}
         />
       ) : (
-        content
+        contentItem
       )
 
     return link

--- a/components/image/slider/src/index.js
+++ b/components/image/slider/src/index.js
@@ -9,9 +9,9 @@ export const IMAGE_SLIDER_COUNTER_POSITIONS = {
   BOTTOM_LEFT: 'bottomLeft',
   BOTTOM_RIGHT: 'bottomRight'
 }
-export const IMAGE_SLIDER_IMAGE_TYPES = {
-  SRC: 'src',
-  CARD: 'card'
+export const IMAGE_SLIDER_CONTENT_TYPES = {
+  IMAGE: 'image',
+  NODE: 'node'
 }
 const NO_OP = () => {}
 const TARGET_BLANK = '_blank'
@@ -30,8 +30,8 @@ const defaultCounterPatternFactory = ({current, total}) => `${current}/${total}`
  * @param {Array} images List given by props.images.
  * @return {Array} List of img elements.
  */
-const getSlides = (currentSlide, images = [], linkFactory) => {
-  return images.map((image, index) => {
+const getSlides = (currentSlide, content = [], linkFactory) => {
+  return content.map((content, index) => {
     const {
       alt,
       height,
@@ -40,13 +40,13 @@ const getSlides = (currentSlide, images = [], linkFactory) => {
       src,
       target = TARGET_BLANK,
       title,
-      type = IMAGE_SLIDER_IMAGE_TYPES.SRC,
+      type = IMAGE_SLIDER_CONTENT_TYPES.IMAGE,
       width
-    } = image
+    } = content
 
     const key = imageKey ? imageKey + index : index
     const children =
-      type === IMAGE_SLIDER_IMAGE_TYPES.SRC ? (
+      type === IMAGE_SLIDER_CONTENT_TYPES.IMAGE ? (
         <img
           alt={alt}
           aria-selected={currentSlide === index}
@@ -58,7 +58,7 @@ const getSlides = (currentSlide, images = [], linkFactory) => {
           width={width}
         />
       ) : (
-        image
+        content
       )
 
     return link
@@ -74,7 +74,7 @@ const getSlides = (currentSlide, images = [], linkFactory) => {
 }
 
 export default function ImageSlider({
-  images = [],
+  images: content = [],
   handleClick = NO_OP,
   sliderOptions = {},
   linkFactory = defaultLinkFactory,
@@ -86,7 +86,7 @@ export default function ImageSlider({
   const [currentSlide, setCurrentSlide] = useState(
     sliderOptions.initialSlide || 0
   )
-  const slides = getSlides(currentSlide, images, linkFactory)
+  const slides = getSlides(currentSlide, content, linkFactory)
   const hasSingleImage = slides.length === 1
   const {useFullHeight} = sliderOptions
 
@@ -148,7 +148,8 @@ ImageSlider.propTypes = {
        */
       key: PropTypes.string,
       link: PropTypes.string,
-      target: PropTypes.string
+      target: PropTypes.string,
+      type: PropTypes.oneOf(Object.values(IMAGE_SLIDER_CONTENT_TYPES))
     }).isRequired
   ),
   /**

--- a/components/image/slider/src/index.js
+++ b/components/image/slider/src/index.js
@@ -28,7 +28,7 @@ const defaultCounterPatternFactory = ({current, total}) => `${current}/${total}`
 
 /**
  * @param {Array} images List given by props.images.
- * @return {Array} List of img elements.
+ * @return {Array} List of img or node elements.
  */
 const getSlides = (currentSlide, content = [], linkFactory) => {
   return content.map((content, index) => {

--- a/components/image/slider/src/index.js
+++ b/components/image/slider/src/index.js
@@ -9,6 +9,10 @@ export const IMAGE_SLIDER_COUNTER_POSITIONS = {
   BOTTOM_LEFT: 'bottomLeft',
   BOTTOM_RIGHT: 'bottomRight'
 }
+export const IMAGE_SLIDER_IMAGE_TYPES = {
+  SRC: 'src',
+  CARD: 'card'
+}
 const NO_OP = () => {}
 const TARGET_BLANK = '_blank'
 
@@ -36,31 +40,36 @@ const getSlides = (currentSlide, images = [], linkFactory) => {
       src,
       target = TARGET_BLANK,
       title,
+      type = IMAGE_SLIDER_IMAGE_TYPES.SRC,
       width
     } = image
 
     const key = imageKey ? imageKey + index : index
-    const img = (
-      <img
-        alt={alt}
-        aria-selected={currentSlide === index}
-        className="sui-ImageSlider-image"
-        key={key}
-        src={src}
-        title={title}
-        height={height}
-        width={width}
-      />
-    )
+    const children =
+      type === IMAGE_SLIDER_IMAGE_TYPES.SRC ? (
+        <img
+          alt={alt}
+          aria-selected={currentSlide === index}
+          className="sui-ImageSlider-image"
+          key={key}
+          src={src}
+          title={title}
+          height={height}
+          width={width}
+        />
+      ) : (
+        image
+      )
+
     return link
       ? linkFactory({
           key,
           target,
           className: '',
-          children: img,
+          children,
           href: link
         })
-      : img
+      : children
   })
 }
 


### PR DESCRIPTION
Feature to be able to render a component as a card inside the image gallery itself.
This is already supported by **react-slidy**, but as we have implemented the component, we only allow to display images through an img tag.

### WITH IMAGE TYPE SRC
<img width="300" alt="Captura de pantalla 2021-05-27 a las 7 18 53" src="https://user-images.githubusercontent.com/31726966/119770037-eb410200-bebb-11eb-96ed-a2463d7afb05.png">

### WITH IMAGE TYPE CARD
<img width="300" alt="Captura de pantalla 2021-05-27 a las 7 19 06" src="https://user-images.githubusercontent.com/31726966/119770110-0744a380-bebc-11eb-88d4-42894fee2bad.png">
