### PR TITLE
Feature/add drawing api to map basic

### DIFF
--- a/components/map/basic/package.json
+++ b/components/map/basic/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "leaflet": "1.2.0"
+    "leaflet": "1.2.0",
+    "leaflet-draw": "1.0.4"
   },
   "keywords": [],
   "author": "",

--- a/components/map/basic/src/index.js
+++ b/components/map/basic/src/index.js
@@ -80,6 +80,9 @@ class MapBasic extends Component {
       mapViewModes: this.props.mapViewModes,
       maxZoom: this.props.maxZoom,
       minZoom: this.props.minZoom,
+      onDrawPolygonStop: this.props.onDrawPolygonStop,
+      onDrawPolygonFinish: this.props.onDrawPolygonFinish,
+      onDrawPolygonRemove: this.props.onDrawPolygonRemove,
       onLayerClick: this.props.onLayerClick,
       onPolygonWithBounds: this.props.onPolygonWithBounds,
       polygons: this.props.polygons,
@@ -238,6 +241,13 @@ MapBasic.propTypes = {
    * A number used to lock the min zoom or zoom out that a user can do.
    */
   minZoom: PropTypes.number,
+  /**
+   * Capture a public API object which enables us to trigger some actions from the outside
+   */
+  onAvailablePublicAPI: PropTypes.func,
+  onDrawPolygonStop: PropTypes.func,
+  onDrawPolygonFinish: PropTypes.func,
+  onDrawPolygonRemove: PropTypes.func,
   onLayerClick: PropTypes.func,
   onMapClick: PropTypes.func,
   onMapDrag: PropTypes.func,
@@ -322,11 +332,7 @@ MapBasic.propTypes = {
   /**
    * This property indicates the action to be performed with the polygon. By DEFAULT it does a fitBounds.
    */
-  onPolygonWithBounds: PropTypes.func,
-  /**
-   * Capture a public API object which enables us to trigger some actions from the outside
-   */
-  onAvailablePublicAPI: PropTypes.func
+  onPolygonWithBounds: PropTypes.func
 }
 
 MapBasic.defaultProps = {
@@ -341,6 +347,9 @@ MapBasic.defaultProps = {
   maxZoom: 20,
   minZoom: 6,
   onAvailablePublicAPI: NO_OP,
+  onDrawPolygonStop: NO_OP,
+  onDrawPolygonFinish: NO_OP,
+  onDrawPolygonRemove: NO_OP,
   onLayerClick: NO_OP,
   onMapClick: NO_OP,
   onMapDrag: NO_OP,

--- a/components/map/basic/src/index.js
+++ b/components/map/basic/src/index.js
@@ -72,6 +72,7 @@ class MapBasic extends Component {
       hoverStyles: this.props.hoverStyles,
       icons: this.props.icons,
       id: this.props.id,
+      initialDrawnPolygon: this.props.initialDrawnPolygon,
       language: this.props.language,
       latitude: this.props.center[0],
       literals: this.props.literals,
@@ -224,6 +225,10 @@ MapBasic.propTypes = {
    * The DOM Id that we would like to have on our map div if none is provided 'map-container' will be its id.
    */
   id: PropTypes.string,
+  /**
+   * A GEO JSON object for an existing user's drawn polygon
+   */
+  initialDrawnPolygon: PropTypes.object,
   /**
    * Language code for requesting a map tile rendered in a specific language.
    */

--- a/components/map/basic/src/index.js
+++ b/components/map/basic/src/index.js
@@ -2,11 +2,6 @@ import {Component} from 'react'
 import PropTypes from 'prop-types'
 import {mapLanguages, mapViewModes, NO_OP} from './leaflet/constants'
 
-const getPublicAPI = mapInstance => ({
-  zoomIn: () => mapInstance._map.zoomIn(),
-  zoomOut: () => mapInstance._map.zoomOut()
-})
-
 class MapBasic extends Component {
   constructor(props) {
     super(props)
@@ -177,7 +172,7 @@ class MapBasic extends Component {
   }
 
   setPublicAPI(mapInstance) {
-    const publicAPI = getPublicAPI(mapInstance)
+    const publicAPI = mapInstance.getPublicAPI()
     this.props.onAvailablePublicAPI(publicAPI)
   }
 

--- a/components/map/basic/src/index.scss
+++ b/components/map/basic/src/index.scss
@@ -16,6 +16,11 @@ $bdrs-minipoi-half: 50%;
     background-image: url('https://raw.githubusercontent.com/Leaflet/Leaflet/master/dist/images/layers-2x.png');
   }
 
+  .leaflet-draw,
+  .leaflet-draw-tooltip {
+    display: none;
+  }
+
   .minipoi {
     background-color: $bgc-minipoi;
     border: $bdc-minipoi;

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -377,4 +377,11 @@ export default class LeafletMap {
       pointsToAdd.length && this.addLayersToMap(pointsToAdd, 'markers')
     }
   }
+
+  getPublicAPI() {
+    return {
+      zoomIn: () => this._map.zoomIn(),
+      zoomOut: () => this._map.zoomOut()
+    }
+  }
 }

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -28,15 +28,6 @@ export default class LeafletMap {
     this.dispatchFirstLoad()
   }
 
-  preInitDrawing(properties) {
-    this._drawnPolygon = null
-    this._drawingEvents = {
-      onDrawPolygonStop: properties.onDrawPolygonStop,
-      onDrawPolygonFinish: properties.onDrawPolygonFinish,
-      onDrawPolygonRemove: properties.onDrawPolygonRemove
-    }
-  }
-
   setViewCenter(coordinates, zoom) {
     this._map.setView(new L.LatLng(coordinates[0], coordinates[1]), zoom)
   }
@@ -385,6 +376,15 @@ export default class LeafletMap {
       pointsToDelete.length &&
         this.layerManager.removeLayersFromGroup(pointsToDelete, 'markers')
       pointsToAdd.length && this.addLayersToMap(pointsToAdd, 'markers')
+    }
+  }
+
+  preInitDrawing(properties) {
+    this._drawnPolygon = null
+    this._drawingEvents = {
+      onDrawPolygonStop: properties.onDrawPolygonStop,
+      onDrawPolygonFinish: properties.onDrawPolygonFinish,
+      onDrawPolygonRemove: properties.onDrawPolygonRemove
     }
   }
 

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -381,6 +381,8 @@ export default class LeafletMap {
 
   preInitDrawing(properties) {
     this._drawnPolygon = null
+
+    // Save events
     this._drawingEvents = {
       onDrawPolygonStop: properties.onDrawPolygonStop,
       onDrawPolygonFinish: properties.onDrawPolygonFinish,
@@ -399,9 +401,8 @@ export default class LeafletMap {
     this._map.addLayer(drawnItems)
 
     // Crate controller
-    const drawControl = new L.Control.Draw({edit: {featureGroup: drawnItems}})
-    this._drawControl = drawControl
-    this._map.addControl(drawControl)
+    this._drawControl = new L.Control.Draw({edit: {featureGroup: drawnItems}})
+    this._map.addControl(this._drawControl)
 
     /**
      * Add drawing events
@@ -422,10 +423,12 @@ export default class LeafletMap {
     new L.Draw.Polygon(this._map, this._drawControl.options.polygon).enable()
   }
 
-  drawingAddFinishedPolygon(drawnPolygon) {
+  drawingAddFinishedPolygon(drawnPolygon, triggerEvent = true) {
     this._drawnPolygon = drawnPolygon
     this._map.addLayer(this._drawnPolygon)
-    this._drawingEvents.onDrawPolygonFinish(this._drawnPolygon)
+    if (triggerEvent) {
+      this._drawingEvents.onDrawPolygonFinish(this._drawnPolygon)
+    }
   }
 
   drawingClear() {

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -380,7 +380,12 @@ export default class LeafletMap {
   }
 
   preInitDrawing(properties) {
-    this._drawnPolygon = null
+    this._drawnPolygon = L.geoJson(properties.initialDrawnPolygon) || null
+
+    // Add an existing drawn polygon if any
+    if (this._drawnPolygon) {
+      this.drawingAddFinishedPolygon(this._drawnPolygon, false)
+    }
 
     // Save events
     this._drawingEvents = {

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -427,14 +427,14 @@ export default class LeafletMap {
     this._drawnPolygon = drawnPolygon
     this._map.addLayer(this._drawnPolygon)
     if (triggerEvent) {
-      this._drawingEvents.onDrawPolygonFinish(this._drawnPolygon)
+      this._drawingEvents.onDrawPolygonFinish(this._drawnPolygon.toGeoJSON())
     }
   }
 
   drawingClear() {
     if (this._drawnPolygon) {
       this._map.removeLayer(this._drawnPolygon)
-      this._drawingEvents.onDrawPolygonRemove(this._drawnPolygon)
+      this._drawingEvents.onDrawPolygonRemove(this._drawnPolygon.toGeoJSON())
     }
   }
 

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -408,12 +408,10 @@ export default class LeafletMap {
   }
 
   drawingStartPolygon() {
-    // Start drawing a new polygon
     new L.Draw.Polygon(this._map, this._drawControl.options.polygon).enable()
   }
 
   drawingClear() {
-    // Remove existing drawn polygon
     if (this.drawnPolygon) this._map.removeLayer(this.drawnPolygon)
   }
 

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -25,6 +25,7 @@ export default class LeafletMap {
       map: this._map
     })
     this.dispatchFirstLoad()
+    this.drawnPolygon = null
   }
 
   setViewCenter(coordinates, zoom) {
@@ -396,8 +397,24 @@ export default class LeafletMap {
 
     // Add events
     this._map.on(L.Draw.Event.CREATED, ({layer}) => {
-      this._map.addLayer(layer)
+      // Add the new drawn polygon
+      this.drawnPolygon = layer
+      this._map.addLayer(this.drawnPolygon)
     })
+  }
+
+  drawingCheckPlugin() {
+    if (!L.Draw) throw new Error('`leaflet-draw` is still not loaded!')
+  }
+
+  drawingStartPolygon() {
+    // Start drawing a new polygon
+    new L.Draw.Polygon(this._map, this._drawControl.options.polygon).enable()
+  }
+
+  drawingClear() {
+    // Remove existing drawn polygon
+    if (this.drawnPolygon) this._map.removeLayer(this.drawnPolygon)
   }
 
   getPublicAPI() {
@@ -407,11 +424,13 @@ export default class LeafletMap {
       drawing: {
         load: () => this.initAsyncDrawingLayer(),
         startPolygon: () => {
-          if (!L.Draw) throw new Error('`leaflet-draw` is still not loaded!')
-          new L.Draw.Polygon(
-            this._map,
-            this._drawControl.options.polygon
-          ).enable()
+          this.drawingCheckPlugin()
+          this.drawingClear()
+          this.drawingStartPolygon()
+        },
+        clear: () => {
+          this.drawingCheckPlugin()
+          this.drawingClear()
         }
       }
     }


### PR DESCRIPTION
- [x] Add Leaflet's Draw plugin and load it only if used
- [x] Move Public API declaration into `leaflet/map.js`
- [x] Add `drawing` section to the Public API
- [x] Add `drawing.startPolygon` method
- [x] Properly manage "committed" polygons (or their layer)
- [x] Add `drawing.clear` method
- [x] Add `onDrawPolygonFinish` event
- [x] Add `onDrawPolygonStop` event
- [x] Add `onDrawPolygonRemove` event
- [x] Receive an existing drawn polygon and show it right from the start
