### PR TITLE
feat(ad/smartbanner): set placeholder space while icons are loading

### DIFF
--- a/components/ad/smartbanner/src/index.js
+++ b/components/ad/smartbanner/src/index.js
@@ -32,11 +32,13 @@ function AdSmartbanner({
         <h3 className="sui-AdSmartbanner-title">{title}</h3>
         <p className="sui-AdSmartbanner-text">{text}</p>
         {ratingValue !== null && (
-          <RatingStar
-            ratingValue={ratingValue}
-            ratingMax={ratingMax}
-            icons={customRatingIcons}
-          />
+          <div className="sui-AdSmartbanner-ratingContainer">
+            <RatingStar
+              ratingValue={ratingValue}
+              ratingMax={ratingMax}
+              icons={customRatingIcons}
+            />
+          </div>
         )}
       </div>
       <button className="sui-AdSmartbanner-buttonInstall" onClick={onClick}>

--- a/components/ad/smartbanner/src/index.scss
+++ b/components/ad/smartbanner/src/index.scss
@@ -57,6 +57,10 @@
     }
   }
 
+  &-ratingContainer {
+    height: $sz-icon-l;
+  }
+
   &-rating {
     padding: $p-ad-smartbanner-rating-container;
 


### PR DESCRIPTION
Trying to fix this jump as it increases CLS

![Screen Recording 2021-07-23 at 11 31 52](https://user-images.githubusercontent.com/17549662/126763874-1016fb87-0c43-4941-827d-eeebd112c940.gif)
