### PR TITLE
feat(components/image/slider): use AtomImage instead default image tag

### DIFF
--- a/components/image/slider/package.json
+++ b/components/image/slider/package.json
@@ -12,9 +12,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "babel-runtime": "6.26.0",
     "@s-ui/component-dependencies": "1",
+    "@s-ui/react-atom-image": "2",
     "@s-ui/react-icons": "1",
+    "babel-runtime": "6.26.0",
     "react-slidy": "4"
   }
 }

--- a/components/image/slider/src/index.js
+++ b/components/image/slider/src/index.js
@@ -2,7 +2,9 @@ import {useState} from 'react'
 import PropTypes from 'prop-types'
 import ReactSlidy from 'react-slidy'
 import cx from 'classnames'
+
 import IconCamera from '@s-ui/react-icons/lib/Camera'
+import AtomImage from '@s-ui/react-atom-image'
 
 export const IMAGE_SLIDER_COUNTER_POSITIONS = {
   BOTTOM_CENTER: 'bottomCenter',
@@ -37,6 +39,7 @@ const getSlides = (currentSlide, content = [], linkFactory) => {
       height,
       key: imageKey,
       link,
+      sources,
       src,
       target = TARGET_BLANK,
       title,
@@ -47,14 +50,15 @@ const getSlides = (currentSlide, content = [], linkFactory) => {
     const key = imageKey ? imageKey + index : index
     const children =
       type === IMAGE_SLIDER_CONTENT_TYPES.IMAGE ? (
-        <img
+        <AtomImage
           alt={alt}
           aria-selected={currentSlide === index}
           className="sui-ImageSlider-image"
+          height={height}
           key={key}
+          sources={sources}
           src={src}
           title={title}
-          height={height}
           width={width}
         />
       ) : (
@@ -148,6 +152,12 @@ ImageSlider.propTypes = {
        */
       key: PropTypes.string,
       link: PropTypes.string,
+      sources: PropTypes.arrayOf(
+        PropTypes.shape({
+          srcset: PropTypes.string,
+          media: PropTypes.string
+        })
+      ),
       target: PropTypes.string,
       type: PropTypes.oneOf(Object.values(IMAGE_SLIDER_CONTENT_TYPES))
     }).isRequired

--- a/components/image/slider/src/index.scss
+++ b/components/image/slider/src/index.scss
@@ -1,6 +1,7 @@
 @import '~@s-ui/theme/lib/settings-compat-v7/index';
 @import '~@s-ui/theme/lib/index';
 @import '~react-slidy/lib/index';
+@import '~@s-ui/react-atom-image/lib/index';
 
 $m-image-slider-counter: $m-m !default;
 $c-image-slider-icon: $c-white !default;


### PR DESCRIPTION
### GOAL

- [x] Use AtomImage instead native image tag
- [x] Be able to receive an array of image source to improve performance.