### PR TITLE
Feat Checkbox nodeLabel prop

### DIFF
--- a/components/form/builder/demo/formPTACar.js
+++ b/components/form/builder/demo/formPTACar.js
@@ -1519,7 +1519,9 @@ export const formPTACar = {
           {
             id: 'terms',
             type: 'picker',
-            label: 'Acepto las condiciones de uso y la política de privacidad',
+            nodeLabel: (
+              <em>Acepto las condiciones de uso y la política de privacidad</em>
+            ),
             hint:
               'En la sección de gestión de privacidad del área de usuario podrás aprender más sobre los distintos usos de tus datos y gestionar los permisos sobre ellos.',
             display: 'checkbox',

--- a/components/form/builder/src/Checkbox/index.js
+++ b/components/form/builder/src/Checkbox/index.js
@@ -49,6 +49,7 @@ const Checkbox = ({
     ...checkboxProps,
     id: checkbox.id,
     label: checkbox.label,
+    nodeLabel: checkbox.nodeLabel,
     value: checked,
     checked,
     checkedIcon: IconCheck,


### PR DESCRIPTION
So far, we're not able to use a `node` as a label for a `checkbox` display on a `picker` type of field.

This *PR* addresses the issue by adding `nodeLabel` when building the `checkbox` component props.

Simple example:

![image](https://user-images.githubusercontent.com/18154356/143018303-afdd0aa9-c0a4-4801-b731-9ffe8b289030.png)
