### PR TITLE
feat(components/card/article): Add the possibility of changing color of card article comments by turning $c-comments into a default value

### DIFF
--- a/components/card/article/src/index.scss
+++ b/components/card/article/src/index.scss
@@ -37,7 +37,7 @@ $fw-article-info-inner: normal !default;
 
   &-comments {
     @include reset-link;
-    $c-comments: $c-gray;
+    $c-comments: $c-gray !default;
     align-items: center;
     align-self: flex-end;
     color: $c-comments;


### PR DESCRIPTION
# Description

This change is made in the context of coches.net rebranding.
We need to change the default color of a card article comments elements (both the comments icon and the number of comments).

Until now, the color was always set to the default gray color and wasn't possible to change it because the token wasn't defined as a default property.

Fixes or or relates to #MTR-49354

# Type of change

* [x] New feature (non-breaking change which adds functionality)

# Screenshots

**Before:**

![image](https://user-images.githubusercontent.com/16169223/149951184-f5a8f283-784e-4f6e-bae3-7902e6b1651b.png)

**After:**

![image](https://user-images.githubusercontent.com/16169223/149951387-291b0884-98e3-4432-9d5f-eeebdf93ea28.png)
