### PR TITLE
add base url to form builder

### DIFF
--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -181,6 +181,9 @@ FormBuilder.propTypes = {
   errors: PropTypes.object,
   alerts: PropTypes.object,
   transformations: PropTypes.func,
+  /**
+   * Defines base api url to be used when a field is set as remote
+   */
   baseAPIURL: PropTypes.string,
   locale: PropTypes.string,
   useNativeFieldType: PropTypes.bool,

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -31,6 +31,7 @@ const FormBuilder = ({
   errors = {},
   alerts = {},
   transformations = (_, value) => value,
+  baseAPIURL = 'https://ptaformbuilder-classifiedads.spain.advgo.net/fieldrules',
   locale = 'es-ES',
   useNativeFieldType = false,
   children: renderer = () => ({})
@@ -56,6 +57,7 @@ const FormBuilder = ({
     const reducerWithRules = reducer(
       rules,
       formID,
+      baseAPIURL,
       responseInterceptor,
       requestInterceptor,
       locale
@@ -101,6 +103,7 @@ const FormBuilder = ({
     const reducerWithRules = reducer(
       rules,
       formID,
+      baseAPIURL,
       responseInterceptor,
       requestInterceptor,
       locale
@@ -178,6 +181,7 @@ FormBuilder.propTypes = {
   errors: PropTypes.object,
   alerts: PropTypes.object,
   transformations: PropTypes.func,
+  baseAPIURL: PropTypes.string,
   locale: PropTypes.string,
   useNativeFieldType: PropTypes.bool,
   children: PropTypes.func

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -31,7 +31,7 @@ const FormBuilder = ({
   errors = {},
   alerts = {},
   transformations = (_, value) => value,
-  baseAPIURL = 'https://ptaformbuilder-classifiedads.spain.advgo.net/fieldrules',
+  baseAPIURL = 'https://ptaformbuilder-classifiedads.spain.advgo.net',
   locale = 'es-ES',
   useNativeFieldType = false,
   children: renderer = () => ({})

--- a/components/form/builder/src/reducer/index.js
+++ b/components/form/builder/src/reducer/index.js
@@ -4,6 +4,7 @@ import {RULES} from './constants'
 export const reducer = (
   rules,
   formID,
+  baseAPIURL,
   responseInterceptor,
   requestInterceptor,
   locale
@@ -17,6 +18,7 @@ export const reducer = (
         rules,
         id,
         formID,
+        baseAPIURL,
         responseInterceptor,
         requestInterceptor,
         locale

--- a/components/form/builder/src/reducer/rules.js
+++ b/components/form/builder/src/reducer/rules.js
@@ -132,7 +132,7 @@ export const fetchRemoteFields = (
       .filter(([field, nextValue]) => nextValue.remote === REMOTE)
       .map(async ([field, nextValue]) => {
         const defaultUrl = encodeURI(
-          `${baseAPIURL}/${field}?${fieldsToQP(fields, formID)}`
+          `${baseAPIURL}/fieldrules/${field}?${fieldsToQP(fields, formID)}`
         )
 
         const defaultConfig = {url: defaultUrl}

--- a/components/form/builder/src/reducer/rules.js
+++ b/components/form/builder/src/reducer/rules.js
@@ -123,6 +123,7 @@ export const shouldApplyRule = (fields, changeField, locale) => when => {
 export const fetchRemoteFields = (
   fields,
   formID,
+  baseAPIURL,
   responseInterceptor,
   requestInterceptor
 ) => async fieldsToChanges => {
@@ -131,15 +132,13 @@ export const fetchRemoteFields = (
       .filter(([field, nextValue]) => nextValue.remote === REMOTE)
       .map(async ([field, nextValue]) => {
         const defaultUrl = encodeURI(
-          `https://ptaformbuilder-classifiedads.spain.advgo.net/fieldrules/${field}?${fieldsToQP(
-            fields,
-            formID
-          )}`
+          `${baseAPIURL}/${field}?${fieldsToQP(fields, formID)}`
         )
 
         const defaultConfig = {url: defaultUrl}
 
         const requestInterceptorConfig = await requestInterceptor({
+          baseAPIURL,
           fieldID: field,
           fields
         })
@@ -177,6 +176,7 @@ export const applyRules = async (
   rules,
   changeField,
   formID,
+  baseAPIURL,
   responseInterceptor,
   requestInterceptor,
   locale
@@ -189,6 +189,7 @@ export const applyRules = async (
   const fetchRemoteFieldsForFieldsAndFormID = fetchRemoteFields(
     fields,
     formID,
+    baseAPIURL,
     responseInterceptor,
     requestInterceptor
   )


### PR DESCRIPTION
This PR adds support to base api url (no breaking change).
- Now clients will be able to change the base api url based on the **environment** 