### PR TITLE
feat(components/topbar/user): Add a scss token to topbar/user to make the icon color customizable from the app theme

### DIFF
--- a/components/topbar/user/src/index.scss
+++ b/components/topbar/user/src/index.scss
@@ -6,17 +6,18 @@
 @import '~@s-ui/react-atom-button/lib/index';
 
 // Topbar user
-$bgc-topbar-user: $c-white !default;
-$bxsh-topbar-user: $bxsh-base !default;
 $bg-topbar-user-brand: null !default;
+$bgc-topbar-user: $c-white !default;
 $bgsz-topbar-user-brand: 100% !default;
-$h-topbar-user-brand-small: 0 !default;
-$w-topbar-user-brand-small: 0 !default;
+$bxsh-topbar-user: $bxsh-base !default;
+$fill-topbar-user-toggle-icon: $c-accent !default;
 $h-topbar-user-brand-large: 0 !default;
-$w-topbar-user-brand-large: 0 !default;
-$size-topbar-user-toggle-icon: 24px !default;
-$w-topbar-user-nav: 90% !default;
+$h-topbar-user-brand-small: 0 !default;
 $maw-topbar-user-nav: 350px !default;
+$size-topbar-user-toggle-icon: 24px !default;
+$w-topbar-user-brand-large: 0 !default;
+$w-topbar-user-brand-small: 0 !default;
+$w-topbar-user-nav: 90% !default;
 
 .html-has-scroll-disabled {
   overflow-y: hidden;
@@ -61,7 +62,7 @@ $maw-topbar-user-nav: 350px !default;
     }
 
     &Icon {
-      fill: $c-accent !important;
+      fill: $fill-topbar-user-toggle-icon !important;
       height: $size-topbar-user-toggle-icon;
       width: $size-topbar-user-toggle-icon;
     }


### PR DESCRIPTION
## Changes

A scss token has been added to the topbar/user component, in order to make customizable the toggle icon color.
Before this change, the topbar icon color was always accent. Now it's accent by default, but can be changed from the app theme.

## Context

coches.net rebranding experiment

## Change type

[x] New feature, not breaking change