### PR TITLE
feat(components/card/article): Add overflow param to card article component

### DIFF
--- a/components/card/article/src/index.scss
+++ b/components/card/article/src/index.scss
@@ -6,9 +6,12 @@
 
 $c-article-tag-types: () !default;
 $fw-article-info-inner: normal !default;
+$ov-card-article: initial !default;
 
 .sui-CardArticle {
   @include sui-card;
+
+  overflow: $ov-card-article;
 
   &-link {
     @include reset-link;


### PR DESCRIPTION
In coches.net, news cards (which use the card/article component from adevinta-spain-components) need to have rounded borders.

We achieved so by using an existing SCSS token. However, we detected that after applying border radius, due to how the card image is positioned, top corners are not visually rounded.

To fix this, we need to apply an overflow hidden attribute to card articles, to ensure that images inside do not overflow the limits of the parent element.