### PR TITLE
fix(components/form/builder): Reemplace outerText by innerText in formbuilder stepper

### DIFF
--- a/components/form/builder/src/Stepper/index.js
+++ b/components/form/builder/src/Stepper/index.js
@@ -13,7 +13,9 @@ const Stepper = ({stepper, tabIndex, onChange, errors, alerts, renderer}) => {
   const errorMessages = errors[stepper.id]
   const alertMessages = alerts[stepper.id]
 
-  const onChangeHandler = ({target: {outerText: OPERATION}}) => {
+  const onChangeHandler = ({target: stepperEvent}) => {
+    const OPERATION = stepperEvent.innerText
+
     if (OPERATION === OPERATIONS.ADD) {
       return onChange(stepper.id, `${Number(stepper.value) + 1}`)
     }


### PR DESCRIPTION
Formbuilder stepper is not working in Firefox, when pressing the buttons nothing happens.

To fix that, I'm replacing "outerText" by "InnerText" in formbuilder stepper onChange handler.

OuterText is not supported by Firefox:
![Captura de pantalla 2022-02-10 a las 12 52 14](https://user-images.githubusercontent.com/17734680/153403729-f8e4c20d-53f5-4c9e-99ef-7c62c3320025.png)

InnerText has compatibility with all browsers:
![Captura de pantalla 2022-02-10 a las 12 52 32](https://user-images.githubusercontent.com/17734680/153403958-a7d5fd68-4883-4c53-9156-56fcf2c87168.png)

