### PR TITLE
feat(components/ad/smartbanner): Add the possibility of defining a custom button element in smartbanner

### DIFF
--- a/components/ad/smartbanner/src/index.js
+++ b/components/ad/smartbanner/src/index.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types'
 import IconCloseDefault from '@s-ui/react-icons/lib/X'
 import cx from 'classnames'
-import RatingStar from './RatingStar'
+import RatingStar from './RatingStar/index.js'
 
 function AdSmartbanner({
+  button: Button,
   buttonText,
   customRatingIcons,
   icon: IconClose = IconCloseDefault,
@@ -49,14 +50,19 @@ function AdSmartbanner({
           </div>
         )}
       </div>
-      <button className={`${baseClass}-buttonInstall`} onClick={onClick}>
-        {buttonText}
-      </button>
+      {Button === undefined ? (
+        <button className={`${baseClass}-buttonInstall`} onClick={onClick}>
+          {buttonText}
+        </button>
+      ) : (
+        <Button onClick={onClick}>{buttonText}</Button>
+      )}
     </div>
   )
 }
 
 AdSmartbanner.propTypes = {
+  button: PropTypes.func,
   buttonText: PropTypes.string.isRequired,
   customRatingIcons: PropTypes.object,
   icon: PropTypes.func,


### PR DESCRIPTION
# Why 

In coches.net, we need to be able to pass a custom element to be used to render the install button of the smartbanner. In a similar way we can now pass a custom element to represent the close button.

Thanks to this change, we will be able to pass a standard AtomButton component that will have the same behaviour and styles than the rest of buttons in the web app.

# What this change does?

This change adds a new prop to the smartbanner component. If the prop is not defined, the component will behave as always with no changes, if the prop is present, its value will be used to render the install button.

# Context

Coches.net rebranding (UX final adjustments).

