### PR TITLE
feat(components/form/builder): Parametrize the withCredentials request option

### DIFF
--- a/components/form/builder/src/reducer/rules.js
+++ b/components/form/builder/src/reducer/rules.js
@@ -24,7 +24,7 @@ const fetch = config =>
   new Promise((resolve, reject) => {
     const {url, headers, withCredentials = true} = config
     const request = new window.XMLHttpRequest()
-    request.onreadystatechange = function() {
+    request.onreadystatechange = function () {
       if (request.readyState === window.XMLHttpRequest.DONE) {
         if (request.status === 200) {
           resolve(request.response)
@@ -34,7 +34,7 @@ const fetch = config =>
       }
     }
 
-    request.onerror = function() {
+    request.onerror = function () {
       reject(Error('Network Error'))
     }
     request.open('GET', url, true)
@@ -119,58 +119,60 @@ export const shouldApplyRule = (fields, changeField, locale) => when => {
   return isValid
 }
 
-export const fetchRemoteFields = (
-  fields,
-  formID,
-  baseAPIURL,
-  responseInterceptor,
-  requestInterceptor,
-  extraParams
-) => async fieldsToChanges => {
-  const remoteFieldsToChange = await Promise.all(
-    Object.entries(fieldsToChanges)
-      .filter(([field, nextValue]) => nextValue.remote === REMOTE)
-      .map(async ([field, nextValue]) => {
-        const defaultUrl = encodeURI(
-          `${baseAPIURL}/fieldrules/${field}?${fieldsToQP(fields, formID)}`
-        )
+export const fetchRemoteFields =
+  (
+    fields,
+    formID,
+    baseAPIURL,
+    responseInterceptor,
+    requestInterceptor,
+    extraParams
+  ) =>
+  async fieldsToChanges => {
+    const remoteFieldsToChange = await Promise.all(
+      Object.entries(fieldsToChanges)
+        .filter(([field, nextValue]) => nextValue.remote === REMOTE)
+        .map(async ([field, nextValue]) => {
+          const defaultUrl = encodeURI(
+            `${baseAPIURL}/fieldrules/${field}?${fieldsToQP(fields, formID)}`
+          )
 
-        const defaultConfig = {url: defaultUrl}
+          const defaultConfig = {url: defaultUrl}
 
-        const requestInterceptorConfig = await requestInterceptor({
-          baseAPIURL,
-          fieldID: field,
-          fields,
-          extraParams
-        })
-        // Config must be follow the Axios pattern
-        // https://github.com/axios/axios
-        const config = requestInterceptorConfig || defaultConfig
+          const requestInterceptorConfig = await requestInterceptor({
+            baseAPIURL,
+            fieldID: field,
+            fields,
+            extraParams
+          })
+          // Config must be follow the Axios pattern
+          // https://github.com/axios/axios
+          const config = requestInterceptorConfig || defaultConfig
 
-        const {remote, ...resetValue} = nextValue
-        return fetch(config)
-          .then(async json => {
-            const {url} = config
-            const nextJSON = await responseInterceptor({
-              field,
-              url,
-              response:
-                typeof json === 'string' || json instanceof String
-                  ? JSON.parse(json)
-                  : json
+          const {remote, ...resetValue} = nextValue
+          return fetch(config)
+            .then(async json => {
+              const {url} = config
+              const nextJSON = await responseInterceptor({
+                field,
+                url,
+                response:
+                  typeof json === 'string' || json instanceof String
+                    ? JSON.parse(json)
+                    : json
+              })
+              return [field, {...resetValue, ...nextJSON}]
             })
-            return [field, {...resetValue, ...nextJSON}]
-          })
-          .catch(error => {
-            console.error(
-              `FAILED requesting remote nextValue for ${field} with error: ${error}`
-            )
-            return [field, {}]
-          })
-      })
-  )
-  return remoteFieldsToChange
-}
+            .catch(error => {
+              console.error(
+                `FAILED requesting remote nextValue for ${field} with error: ${error}`
+              )
+              return [field, {}]
+            })
+        })
+    )
+    return remoteFieldsToChange
+  }
 
 export const applyRules = async (
   fields,

--- a/components/form/builder/src/reducer/rules.js
+++ b/components/form/builder/src/reducer/rules.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import {operators} from './operators'
+import {operators} from './operators.js'
 import {
   IN,
   INPATTERN,
@@ -17,14 +17,14 @@ import {
   SUPERSET,
   NSUPERSET,
   HIDDEN
-} from './constants'
-import {changeFieldById, fieldsToQP} from './fields'
+} from './constants.js'
+import {changeFieldById, fieldsToQP} from './fields.js'
 
 const fetch = config =>
   new Promise((resolve, reject) => {
-    const {url, headers} = config
+    const {url, headers, withCredentials = true} = config
     const request = new window.XMLHttpRequest()
-    request.onreadystatechange = function () {
+    request.onreadystatechange = function() {
       if (request.readyState === window.XMLHttpRequest.DONE) {
         if (request.status === 200) {
           resolve(request.response)
@@ -34,7 +34,7 @@ const fetch = config =>
       }
     }
 
-    request.onerror = function () {
+    request.onerror = function() {
       reject(Error('Network Error'))
     }
     request.open('GET', url, true)
@@ -42,9 +42,8 @@ const fetch = config =>
       Object.entries(headers).map(([header, value]) =>
         request.setRequestHeader(header, value)
       )
-
     request.responseType = 'json'
-    request.withCredentials = true
+    request.withCredentials = withCredentials
     request.send()
   })
 


### PR DESCRIPTION
# Description

In CNET PRO we are migrating some endpoints to PACT. Some of these endpoints are in charge of calculating possible field values for a form which uses this form builder.

In this scenario, if the request `withCredentials` option is enabled, a CORS error occurs. We think that the most feasible solution seems to optionally disable this option, as we don't need it for our requests.

Thanks to 💟  @xmurcia @davidmartin84  and @IgnacioND, who contributed during this issue investigation.