### PR TITLE
Feat markdown service callback

### DIFF
--- a/components/services/markdown/demo/index.js
+++ b/components/services/markdown/demo/index.js
@@ -1,0 +1,41 @@
+import ServicesMarkdown from 'components/services/markdown/src/index'
+
+const handleOnLoad = ({html, setHtml}) => {
+  console.log('markdown content loaded')
+  console.log('html:', html)
+  setHtml(
+    '<h1>Hello World</h1><p>This content was injected after the markdown was loaded</p>'
+  )
+}
+
+const markdownStyles = {
+  backgroundColor: 'white',
+  borderRadius: '24px',
+  boxShadow: '0px 0px 16px rgba(0, 0, 0, 0.1)',
+  margin: '24px',
+  padding: '16px'
+}
+const MARKDOWN_URL =
+  'https://raw.githubusercontent.com/SUI-Components/adevinta-spain-components/master/components/services/markdown/demo/example.md'
+
+const DemoServicesMarkdownGroup = () => {
+  return (
+    <>
+      <h1>
+        ServiceMarkdown component loading contents from an external source
+      </h1>
+      <div style={markdownStyles}>
+        <ServicesMarkdown src={MARKDOWN_URL} />
+      </div>
+      <h1>
+        ServiceMarkdown component loading contents from an external source and
+        overriding it when loaded
+      </h1>
+      <div style={markdownStyles}>
+        <ServicesMarkdown src={MARKDOWN_URL} onLoad={handleOnLoad} />
+      </div>
+    </>
+  )
+}
+
+export default DemoServicesMarkdownGroup

--- a/components/services/markdown/demo/index.js
+++ b/components/services/markdown/demo/index.js
@@ -1,8 +1,7 @@
 import ServicesMarkdown from 'components/services/markdown/src/index'
 
 const handleOnLoad = ({html, setHtml}) => {
-  console.log('markdown content loaded')
-  console.log('html:', html)
+  console.log('markdown content loaded', {html})
   setHtml(
     '<h1>Hello World</h1><p>This content was injected after the markdown was loaded</p>'
   )

--- a/components/services/markdown/demo/playground
+++ b/components/services/markdown/demo/playground
@@ -1,1 +1,0 @@
-return (<ServiceMarkdown src="https://raw.githubusercontent.com/SUI-Components/schibsted-spain-components/master/demo/services/markdown/example.md"/>)

--- a/components/services/markdown/src/index.js
+++ b/components/services/markdown/src/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 const STATUS_OK = 200
 const COMPLETED = 4
 
-function ServiceMarkdown({src}) {
+function ServiceMarkdown({onLoad = () => {}, src}) {
   const [html, setHtml] = useState('')
   const [loaded, setLoaded] = useState(false)
 
@@ -29,6 +29,7 @@ function ServiceMarkdown({src}) {
   useEffect(
     function () {
       if (loaded) {
+        onLoad({html, setHtml})
         const id = document.location.hash.substring(1)
         if (id) {
           const element = document.getElementById(id)
@@ -37,7 +38,8 @@ function ServiceMarkdown({src}) {
         }
       }
     },
-    [loaded]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [loaded, onLoad]
   )
 
   return <div dangerouslySetInnerHTML={{__html: html}} />
@@ -47,7 +49,14 @@ ServiceMarkdown.displayName = 'ServiceMarkdown'
 
 ServiceMarkdown.propTypes = {
   /**
-   * The web address of the markdwon file to fetch and parse
+   * A simple function to be called when the markdown is loaded.
+   * @type {function}
+   * @returns {object} Object containing html value and setHtml function.
+   *
+   */
+  onLoad: PropTypes.func,
+  /**
+   * The web address of the markdown file to fetch and parse
    * For example "https://mycdn.com/myfile.md"
    */
   src: PropTypes.string.isRequired


### PR DESCRIPTION
On this PR we're adding a new prop `onLoad` that will allow us to know when the markup has been loaded.

It also returns `html` as the markup `html` content and `setHtml`, the setter function from `useState`.

A `useCase` for this new prop could be, for instance: 
- a markdown text with placeholders is loaded
- those placeholders need to be updated on the text within the component