### PR TITLE
fix(components/form/builder): rules applied during init

### DIFF
--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -42,9 +42,9 @@ const FormBuilder = ({
   const __PERFORMANCE_UGLY_HACK_STATE_FIELDS__ = useRef()
   __PERFORMANCE_UGLY_HACK_STATE_FIELDS__.current = stateFields
 
-  const changeField = (fieldId, fieldValue) => {
+  const changeField = (fieldId, fieldValue, previousFields) => {
     const nextFields = changeFieldById(
-      __PERFORMANCE_UGLY_HACK_STATE_FIELDS__.current,
+      previousFields || __PERFORMANCE_UGLY_HACK_STATE_FIELDS__.current,
       fieldId,
       {value: fieldValue}
     )
@@ -124,7 +124,11 @@ const FormBuilder = ({
           return previousFields
         }
 
-        const nextFieldsChanged = changeField(fieldId, initFields[fieldId])
+        const nextFieldsChanged = changeField(
+          fieldId,
+          initFields[fieldId],
+          previousFields
+        )
 
         const nextFieldsWithRules = await reducerWithRules(nextFieldsChanged, {
           type: RULES,


### PR DESCRIPTION
This PR:
- Fixes an issue where some rules were being removed during first check (mount).
```js
const businessFormJSON = {
  form: {
    id: 'billing-form',
    type: 'group',
    rules: {
      province: [
        {
          when: [
            {
              operator: 'NIN',
              id: 'country',
              value: ['ES']
            }
          ],
          then: {
            data: {
              value: '',
              hidden: true
            }
          }
        },
        {
          when: [
            {
              operator: 'IN',
              id: 'country',
              value: ['ES']
            }
          ],
          then: {
            data: {
              value: 'barcelona',
              hidden: false
            }
          }
        }
      ]
    },
    fields: [
      {
        id: 'country',
        type: 'picker',
        display: 'dropdown',
        label: 'País',
        required: true,
        value: 'ES',
        datalist: [
          {
            value: 'ES',
            text: 'España'
          },
          {
            value: 'DE',
            text: 'Alemania'
          }
        ],
        constraints: [
          {
            property: {
              notnull: ''
            },
            message: 'Este campo es requerido'
          }
        ]
      },
      {
        id: 'province',
        type: 'picker',
        display: 'dropdown',
        label: 'Provincia',
        datalist: [
          {
            value: 'alava',
            text: 'Álava'
          },
          {
            value: 'alicante',
            text: 'Alicante'
          }
        ]
      },
      {
        id: 'locality',
        type: 'text',
        display: '',
        label: 'Localidad',
        required: true,
        constraints: [
          {
            property: {
              notnull: ''
            },
            message: 'Este campo es requerido'
          }
        ]
      }
    ]
  }
}

export default businessFormJSON
```
In the example above when `province` was different from `ES` the `then` of the first rule was not being applied because it was erased by the `locality` iteration.