### PR TITLE
feat(components/dropdown/user): Replace custom notification by badgeCounter component

### DIFF
--- a/components/dropdown/user/package.json
+++ b/components/dropdown/user/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-molecule-badge-counter": "1"
   }
 }

--- a/components/dropdown/user/src/index.js
+++ b/components/dropdown/user/src/index.js
@@ -2,6 +2,9 @@
 import {useReducer} from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import MoleculeBadgeCounter, {
+  moleculeBadgeCounterSizes
+} from '@s-ui/react-molecule-badge-counter'
 
 import {reducerActions, reducerInitialState, reducer} from './reducer'
 
@@ -57,7 +60,10 @@ const DropdownUser = ({
           <span className="sui-DropdownUserMenu-listText">{text}</span>
           {hasLinkNotifications && (
             <span className="sui-DropdownUserMenu-listNotification">
-              {notifications}
+              <MoleculeBadgeCounter
+                label={notifications}
+                size={moleculeBadgeCounterSizes.LARGE}
+              />
             </span>
           )}
         </Link>

--- a/components/dropdown/user/src/index.scss
+++ b/components/dropdown/user/src/index.scss
@@ -2,6 +2,7 @@
 
 @import '~@s-ui/theme/lib/index';
 @import '~@s-ui/theme/lib/settings-compat-v7/index';
+@import '~@s-ui/react-molecule-badge-counter/lib/index';
 @import 'settings';
 
 .sui-DropdownUser {
@@ -155,11 +156,9 @@
       }
 
       &Notification {
-        @include sui-badge-notification;
-        margin-top: -$size-badge-notification * 0.5;
+        margin-bottom: $size-badge-notification * 0.5;
         position: absolute;
-        right: $p-h-small;
-        top: 50%;
+        right: $p-h-large;
       }
 
       &Link:hover &Text {


### PR DESCRIPTION
Replace custom notification by badgeCounter component into the dropdown user menu.

**Before:**

<img width="404" alt="Captura de pantalla 2022-05-04 a las 12 42 13" src="https://user-images.githubusercontent.com/75249490/166666734-1698fa93-3bfc-4ac6-b414-e1358c5099b3.png">


**After:**

<img width="405" alt="Captura de pantalla 2022-05-04 a las 12 40 59" src="https://user-images.githubusercontent.com/75249490/166666577-43f76686-4b20-47bf-834b-b79171964aea.png">
