### PR TITLE
Use matchMedia as default value when is supported

### DIFF
--- a/components/react/hooks/jest-tests/useMediaQuery.test.js
+++ b/components/react/hooks/jest-tests/useMediaQuery.test.js
@@ -2,6 +2,8 @@
 import {renderHook} from '@testing-library/react-hooks'
 import mediaQuery from 'css-mediaquery'
 
+import {useMediaQuery} from '../src/index.js'
+
 // @see: https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
@@ -16,9 +18,6 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn()
   }))
 })
-
-// eslint-disable-next-line import/first
-import {useMediaQuery} from '../src/index.js'
 
 describe('useMediaQuery hook', () => {
   describe('without window.matchMedia', () => {

--- a/components/react/hooks/jest-tests/useMediaQuery.test.js
+++ b/components/react/hooks/jest-tests/useMediaQuery.test.js
@@ -1,0 +1,87 @@
+/* eslint-env jest */
+import {renderHook} from '@testing-library/react-hooks'
+import mediaQuery from 'css-mediaquery'
+
+// @see: https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  }))
+})
+
+// eslint-disable-next-line import/first
+import {useMediaQuery} from '../src/index.js'
+
+describe('useMediaQuery hook', () => {
+  describe('without window.matchMedia', () => {
+    let originalMatchmedia
+    beforeEach(() => {
+      originalMatchmedia = window.matchMedia
+      window.matchMedia = undefined
+    })
+    afterEach(() => {
+      window.matchMedia = originalMatchmedia
+    })
+
+    it('should work without window.matchMedia available', () => {
+      expect(typeof window.matchMedia).toEqual('undefined')
+      const {result} = renderHook(() => useMediaQuery('(min-width:100px)'))
+
+      expect(result.current).toBe(false)
+    })
+    it('should work without window.matchMedia available and defaultMatches true', () => {
+      expect(typeof window.matchMedia).toEqual('undefined')
+      const {result} = renderHook(() =>
+        useMediaQuery('(min-width:100px)', {defaultMatches: true})
+      )
+      expect(result.current).toBe(true)
+    })
+  })
+
+  describe('with window.matchMedia', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should the match value to be false when not matches the query', () => {
+      const screenWidth = 600
+      jest.spyOn(window, 'matchMedia').mockImplementation(query => ({
+        matches: mediaQuery.match(query, {width: screenWidth}),
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn()
+      }))
+
+      const {result} = renderHook(() => useMediaQuery('(min-width: 900px)'))
+      expect(result.current).toBe(false)
+    })
+    it('should the match value to be true when matches the query', () => {
+      const screenWidth = 1280
+      jest.spyOn(window, 'matchMedia').mockImplementation(query => ({
+        matches: mediaQuery.match(query, {width: screenWidth}),
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn()
+      }))
+
+      const {result} = renderHook(() => useMediaQuery('(min-width: 900px)'))
+      expect(result.current).toBe(true)
+    })
+  })
+})

--- a/components/react/hooks/package.json
+++ b/components/react/hooks/package.json
@@ -14,5 +14,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "css-mediaquery": "0.1.2"
+  }
 }

--- a/components/react/hooks/src/useMediaQuery/index.js
+++ b/components/react/hooks/src/useMediaQuery/index.js
@@ -1,13 +1,16 @@
 import {useState, useEffect} from 'react'
 
-const supportMatchMedia =
-  typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined'
-
 function useMediaQuery(queryInput, {defaultMatches = false} = {}) {
-  const query = queryInput.replace(/^@media( ?)/m, '')
+  const supportMatchMedia =
+    typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined'
   const matchMedia = supportMatchMedia ? window.matchMedia : null
 
-  const [match, setMatch] = useState(defaultMatches)
+  const query = queryInput.replace(/^@media( ?)/m, '')
+
+  const [match, setMatch] = useState(() => {
+    if (supportMatchMedia) return matchMedia(query).matches
+    return defaultMatches
+  })
 
   useEffect(() => {
     let active = true
@@ -25,7 +28,7 @@ function useMediaQuery(queryInput, {defaultMatches = false} = {}) {
       active = false
       queryList.removeListener(updateMatch)
     }
-  }, [query, matchMedia])
+  }, [query, matchMedia, supportMatchMedia])
 
   return match
 }

--- a/components/react/hooks/src/useMediaQuery/index.js
+++ b/components/react/hooks/src/useMediaQuery/index.js
@@ -1,21 +1,21 @@
 import {useState, useEffect} from 'react'
 
 function useMediaQuery(queryInput, {defaultMatches = false} = {}) {
-  const supportMatchMedia =
+  const hasSupportMatchMedia =
     typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined'
-  const matchMedia = supportMatchMedia ? window.matchMedia : null
+  const matchMedia = hasSupportMatchMedia ? window.matchMedia : null
 
   const query = queryInput.replace(/^@media( ?)/m, '')
 
   const [match, setMatch] = useState(() => {
-    if (supportMatchMedia) return matchMedia(query).matches
+    if (hasSupportMatchMedia) return matchMedia(query).matches
     return defaultMatches
   })
 
   useEffect(() => {
     let active = true
 
-    if (!supportMatchMedia) return
+    if (!hasSupportMatchMedia) return
 
     const queryList = matchMedia(query)
     const updateMatch = () => {
@@ -28,7 +28,7 @@ function useMediaQuery(queryInput, {defaultMatches = false} = {}) {
       active = false
       queryList.removeListener(updateMatch)
     }
-  }, [query, matchMedia, supportMatchMedia])
+  }, [query, matchMedia, hasSupportMatchMedia])
 
   return match
 }


### PR DESCRIPTION
# Use `window.matchMedia` as default value when is supported.

## Context

The current behaviour of hook is that we always initialize [the state value `match`](https://github.com/SUI-Components/adevinta-spain-components/blob/master/components/react/hooks/src/useMediaQuery/index.js#L10) with [`defaultMatches` value](https://github.com/SUI-Components/adevinta-spain-components/blob/master/components/react/hooks/src/useMediaQuery/index.js#L6) and really we use `window.match` after render of the DOM by `useEffect`. That causes in client where `window.match` is supported a change of `match` value and renders of the two cases that are using the `match` value.

Example:
As you can see below in the images, console section, `Mobile` and `Desktop` components will be rendered.

![Captura de pantalla 2022-04-07 a las 13 42 24](https://user-images.githubusercontent.com/1263588/171811110-0b545a48-b79f-4822-9302-ab4c3695c11e.png)
![Captura de pantalla 2022-04-07 a las 13 41 27](https://user-images.githubusercontent.com/1263588/171811129-8503ef44-5201-4cec-b14b-b5f0a480b763.png)

Demo of example: https://codesandbox.io/s/great-forest-zd7syl?file=/src/App.js 

## Implementations:

- Use `window.match` when is supported as priorized value over defaultMatches.
- Move `supportMatchMedia` inside of hook for not to use its value by closure if the file `useMediaQuery/index.js` had already been loaded.
- Add unit test for `useMediaQuery` hook.
- Install [`css-mediaquery`](https://github.com/ericf/css-mediaquery) as dev dependency for support implementation of calculate of matches via screen with.