### PR TITLE
Feat/rollback usemediaquery

### DIFF
--- a/components/react/hooks/jest-tests/useMediaQuery.test.js
+++ b/components/react/hooks/jest-tests/useMediaQuery.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
-import {renderHook} from '@testing-library/react-hooks'
 import mediaQuery from 'css-mediaquery'
+
+import {renderHook} from '@testing-library/react-hooks'
 
 import {useMediaQuery} from '../src/index.js'
 
@@ -65,22 +66,6 @@ describe('useMediaQuery hook', () => {
 
       const {result} = renderHook(() => useMediaQuery('(min-width: 900px)'))
       expect(result.current).toBe(false)
-    })
-    it('should the match value to be true when matches the query', () => {
-      const screenWidth = 1280
-      jest.spyOn(window, 'matchMedia').mockImplementation(query => ({
-        matches: mediaQuery.match(query, {width: screenWidth}),
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn()
-      }))
-
-      const {result} = renderHook(() => useMediaQuery('(min-width: 900px)'))
-      expect(result.current).toBe(true)
     })
   })
 })

--- a/components/react/hooks/src/useMediaQuery/index.js
+++ b/components/react/hooks/src/useMediaQuery/index.js
@@ -1,21 +1,18 @@
 import {useState, useEffect} from 'react'
 
+const supportMatchMedia =
+  typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined'
+
 function useMediaQuery(queryInput, {defaultMatches = false} = {}) {
-  const hasSupportMatchMedia =
-    typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined'
-  const matchMedia = hasSupportMatchMedia ? window.matchMedia : null
-
   const query = queryInput.replace(/^@media( ?)/m, '')
+  const matchMedia = supportMatchMedia ? window.matchMedia : null
 
-  const [match, setMatch] = useState(() => {
-    if (hasSupportMatchMedia) return matchMedia(query).matches
-    return defaultMatches
-  })
+  const [match, setMatch] = useState(defaultMatches)
 
   useEffect(() => {
     let active = true
 
-    if (!hasSupportMatchMedia) return
+    if (!supportMatchMedia) return
 
     const queryList = matchMedia(query)
     const updateMatch = () => {
@@ -28,7 +25,7 @@ function useMediaQuery(queryInput, {defaultMatches = false} = {}) {
       active = false
       queryList.removeListener(updateMatch)
     }
-  }, [query, matchMedia, hasSupportMatchMedia])
+  }, [query, matchMedia])
 
   return match
 }

--- a/components/react/hooks/src/useMediaQuery/index.js
+++ b/components/react/hooks/src/useMediaQuery/index.js
@@ -1,4 +1,4 @@
-import {useState, useEffect} from 'react'
+import {useEffect, useState} from 'react'
 
 const supportMatchMedia =
   typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined'


### PR DESCRIPTION
Add rollback of `useMediaQuery` for compatibility in some verticals

After talk with @quinwacca and @tomcask we found some different behaviour in carfactory web and we've decided do rollback of this PR https://github.com/SUI-Components/adevinta-spain-components/pull/498

