### PR TITLE
Feat topbar use isomorphic layout

### DIFF
--- a/components/topbar/user/package.json
+++ b/components/topbar/user/package.json
@@ -16,6 +16,7 @@
     "@s-ui/react-atom-button": "1",
     "@s-ui/react-dropdown-basic": "1",
     "@s-ui/react-dropdown-user": "1",
+    "@s-ui/react-hooks": "1",
     "@s-ui/react-icons": "1"
   }
 }

--- a/components/topbar/user/src/index.js
+++ b/components/topbar/user/src/index.js
@@ -1,11 +1,12 @@
 /* eslint-disable react/prop-types */
 import PropTypes from 'prop-types'
-import {useState, useEffect, useLayoutEffect, useRef} from 'react'
+import {useState, useEffect, useRef} from 'react'
 import cx from 'classnames'
 import Menu from '@s-ui/react-icons/lib/Menu'
 import DropdownBasic from '@s-ui/react-dropdown-basic'
 import DropdownUser from '@s-ui/react-dropdown-user'
 import AtomButton, {atomButtonSizes} from '@s-ui/react-atom-button'
+import useIsomorphicLayoutEffect from '@s-ui/react-hooks/lib/useIsomorphicLayoutEffect/index.js'
 
 const noop = () => {}
 
@@ -80,7 +81,9 @@ export default function TopbarUser({
     }
   }
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
+    // Early return if not on client
+    if (window === undefined) return
     /**
      * Set the display state for toggle button.
      */


### PR DESCRIPTION
...and early return if not on client.

There's an ongoing server error caused by the use of `useLayoutEffect` on this component.

````
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
    at TopbarUser (webpack:///../node_modules/@s-ui/react-topbar-user/lib/index.js?:44:36)
    at div
    at SharedTopbar (webpack:///../components/shared/topbar/lib/index.js?:23:524)
    at Topbar (webpack:///./components/Topbar/index.js?:10:329)
    at div
    at div
    at div
    at AdvertisingRoadblock (webpack:///../components/advertising/roadblock/lib/index.js?:18:97)
    at AdvertisingProvider (webpack:///../node_modules/@adv-ui/adit-saitama-context-advertising/lib/AdvertisingProvider/index.js?:53:36)
    at AdvertisingProvider (webpack:///../node_modules/@adv-ui/adit-saitama-context-advertising/lib/AdvertisingProvider/index.js?:53:36)
    at ErrorAppBoundary (webpack:///../node_modules/@s-ui/react-error-app-boundary/lib/index.js?:27:29)
    at ErrorAppBoundary (webpack:///../components/error/appBoundary/lib/component.js?:12:72)
    at ErrorAppBoundary
    at App (webpack:///./components/App/index.js?:25:105)
    at WrappedComponent (webpack:///./hocs/withThirdPartiesParam.js?:9:150)
    at Router (webpack:///../node_modules/@s-ui/react-router/lib/Router.js?:59:24)
    at HeadProvider (webpack:///../node_modules/react-head/dist/index.esm.js?:115:35)
    at InitialContext
````

This could be having some effect on our server's performance, according to this article:
https://expressjs.com/en/advanced/best-practice-performance.html#do-logging-correctly