### PR TITLE
Feat/scmi 75314/hidden links in link basic

### DIFF
--- a/components/link/basic/package.json
+++ b/components/link/basic/package.json
@@ -9,7 +9,8 @@
     "build:styles": "cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@s-ui/react-primitive-polymorphic-element": "1"
   },
   "devDependencies": {
     "@s-ui/react-router": "1"

--- a/components/link/basic/src/index.js
+++ b/components/link/basic/src/index.js
@@ -93,6 +93,7 @@ LinkBasic.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   handleClick: PropTypes.func,
+  hideSemanticLink: PropTypes.bool,
   icon: PropTypes.element,
   literal: PropTypes.string,
   rel: PropTypes.string,

--- a/components/link/basic/src/index.js
+++ b/components/link/basic/src/index.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 
 import {Link} from '@s-ui/react-router'
+import PolymorphicElement from '@s-ui/react-primitive-polymorphic-element'
 
 const renderContent = (icon, literal) =>
   icon && literal ? (
@@ -14,6 +15,7 @@ const renderContent = (icon, literal) =>
   )
 
 export default function LinkBasic({
+  as = 'a',
   className,
   disabled,
   handleClick,
@@ -22,19 +24,38 @@ export default function LinkBasic({
   rel,
   target,
   title,
-  hideSemanticLink,
   useReactRouterLinks,
   url = '#'
 }) {
   const BASE_CLASS = 'sui-LinkBasic'
-  const linkClassName = cx(BASE_CLASS, className, {
-    [`${BASE_CLASS}-button`]: hideSemanticLink
-  })
+  const linkBasicClassName = cx(BASE_CLASS, className)
   const content = renderContent(icon, literal)
+  const isAnchor = as === 'a'
+  const commonProps = {
+    className: linkBasicClassName,
+    rel,
+    title
+  }
+  const anchorProps = {
+    href: url,
+    target
+  }
+  const linkProps = {
+    target,
+    to: url
+  }
+
+  const onClick = () => {
+    handleClick && handleClick()
+
+    if (!isAnchor) {
+      window.location.href = url
+    }
+  }
 
   if (disabled) {
     return (
-      <span className={linkClassName} onClick={handleClick} title={title}>
+      <span onClick={handleClick} {...commonProps}>
         {content}
       </span>
     )
@@ -42,58 +63,31 @@ export default function LinkBasic({
 
   if (useReactRouterLinks) {
     return (
-      <Link
-        className={linkClassName}
-        onClick={handleClick}
-        rel={rel}
-        target={target}
-        title={title}
-        to={url}
-      >
+      <Link onClick={handleClick} {...commonProps} {...linkProps}>
         {content}
       </Link>
     )
   }
 
-  if (hideSemanticLink) {
-    const handleHiddenLinkClick = () => {
-      handleClick && handleClick()
-      window.location.href = url
-    }
-
-    return (
-      <button
-        className={linkClassName}
-        name={title}
-        onClick={handleHiddenLinkClick}
-        rel={rel}
-      >
-        {content}
-      </button>
-    )
-  }
-
   return (
-    <a
-      className={linkClassName}
-      href={url}
-      onClick={handleClick}
-      rel={rel}
-      target={target}
-      title={title}
+    <PolymorphicElement
+      as={as}
+      onClick={onClick}
+      {...commonProps}
+      {...(isAnchor ? anchorProps : {})}
     >
       {content}
-    </a>
+    </PolymorphicElement>
   )
 }
 
 LinkBasic.displayName = 'LinkBasic'
 
 LinkBasic.propTypes = {
+  as: PropTypes.string,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   handleClick: PropTypes.func,
-  hideSemanticLink: PropTypes.bool,
   icon: PropTypes.element,
   literal: PropTypes.string,
   rel: PropTypes.string,

--- a/components/link/basic/src/index.js
+++ b/components/link/basic/src/index.js
@@ -22,13 +22,13 @@ export default function LinkBasic({
   rel,
   target,
   title,
-  useHiddenLink,
+  hideSemanticLink,
   useReactRouterLinks,
   url = '#'
 }) {
   const BASE_CLASS = 'sui-LinkBasic'
   const linkClassName = cx(BASE_CLASS, className, {
-    [`${BASE_CLASS}-button`]: useHiddenLink
+    [`${BASE_CLASS}-button`]: hideSemanticLink
   })
   const content = renderContent(icon, literal)
 
@@ -55,7 +55,7 @@ export default function LinkBasic({
     )
   }
 
-  if (useHiddenLink) {
+  if (hideSemanticLink) {
     const handleHiddenLinkClick = () => {
       handleClick && handleClick()
       window.location.href = url

--- a/components/link/basic/src/index.js
+++ b/components/link/basic/src/index.js
@@ -22,10 +22,14 @@ export default function LinkBasic({
   rel,
   target,
   title,
+  useHiddenLink,
   useReactRouterLinks,
   url = '#'
 }) {
-  const linkClassName = cx('sui-LinkBasic', className)
+  const BASE_CLASS = 'sui-LinkBasic'
+  const linkClassName = cx(BASE_CLASS, className, {
+    [`${BASE_CLASS}-button`]: useHiddenLink
+  })
   const content = renderContent(icon, literal)
 
   if (disabled) {
@@ -48,6 +52,24 @@ export default function LinkBasic({
       >
         {content}
       </Link>
+    )
+  }
+
+  if (useHiddenLink) {
+    const handleHiddenLinkClick = () => {
+      handleClick && handleClick()
+      window.location.href = url
+    }
+
+    return (
+      <button
+        className={linkClassName}
+        name={title}
+        onClick={handleHiddenLinkClick}
+        rel={rel}
+      >
+        {content}
+      </button>
     )
   }
 

--- a/components/link/basic/src/index.scss
+++ b/components/link/basic/src/index.scss
@@ -3,19 +3,16 @@
 @import './settings';
 
 .sui-LinkBasic {
+  background-color: transparent;
+  border: none;
   color: $c-link-basic;
   cursor: pointer;
+  display: inline;
   font-size: $fz-link-basic;
+  line-height: normal;
   margin: $m-link-basic;
+  padding: 0;
   text-decoration: $td-link-basic;
-
-  &-button {
-    background-color: transparent;
-    border: none;
-    display: inline;
-    line-height: normal;
-    padding: 0;
-  }
 
   &-icon {
     margin-right: $m-link-basic-icon;

--- a/components/link/basic/src/index.scss
+++ b/components/link/basic/src/index.scss
@@ -9,6 +9,14 @@
   margin: $m-link-basic;
   text-decoration: $td-link-basic;
 
+  &-button {
+    background-color: transparent;
+    border: none;
+    display: inline;
+    line-height: normal;
+    padding: 0;
+  }
+
   &-icon {
     margin-right: $m-link-basic-icon;
   }


### PR DESCRIPTION
Add prop to support hide link to crawlers in LinkBasic component.

The technique used is to use semantic `button` instead `a`. Documentation can be found here: 
[https://www.searchenginejournal.com/prg-pattern-the-new-nofollow/392862/#close](https://www.searchenginejournal.com/prg-pattern-the-new-nofollow/392862/#close)

<img width="2143" alt="image" src="https://user-images.githubusercontent.com/66824007/187862580-ca8ec0c8-c4a8-4d27-ae0f-58e74bdf48ed.png">
