### PR TITLE
Fix: Parse localStorage event value if it's boolean

### DIFF
--- a/components/react/hooks/src/useLocalStorage/index.js
+++ b/components/react/hooks/src/useLocalStorage/index.js
@@ -85,7 +85,7 @@ function useLocalStorage(key, initialValue) {
     const eventKey = event.key || event.detail?.key
     const eventValue = event.newValue || event.detail?.newValue
 
-    if (eventKey === key) setValue(eventValue)
+    if (eventKey === key) setValue(JSON.parse(eventValue))
   }
 
   useEventListener(LOCAL_STORAGE_KEY, handleStorageChange)

--- a/components/react/hooks/src/useLocalStorage/index.js
+++ b/components/react/hooks/src/useLocalStorage/index.js
@@ -13,7 +13,7 @@ const hasWindow = () => typeof window !== 'undefined'
  * @param initialValue any
  * @returns {UseLocalStorageResult}
  */
-function useLocalStorage(key, initialValue) {
+function useLocalStorage(key, initialValue, isBoolean = false) {
   /**
    * The loadStoredValue retrieve the stored value
    * from the localStorage if it exists.
@@ -85,7 +85,8 @@ function useLocalStorage(key, initialValue) {
     const eventKey = event.key || event.detail?.key
     const eventValue = event.newValue || event.detail?.newValue
 
-    if (eventKey === key) setValue(JSON.parse(eventValue))
+    if (eventKey === key)
+      setValue(isBoolean ? JSON.parse(eventValue) : eventValue)
   }
 
   useEventListener(LOCAL_STORAGE_KEY, handleStorageChange)

--- a/components/react/hooks/src/useLocalStorage/index.js
+++ b/components/react/hooks/src/useLocalStorage/index.js
@@ -11,9 +11,10 @@ const hasWindow = () => typeof window !== 'undefined'
  *
  * @param key string
  * @param initialValue any
+ * @param parserFn func - Function applied in the listener when changing a local storage value manually in the browser
  * @returns {UseLocalStorageResult}
  */
-function useLocalStorage(key, initialValue, isBoolean = false) {
+function useLocalStorage(key, initialValue, parserFn = value => value) {
   /**
    * The loadStoredValue retrieve the stored value
    * from the localStorage if it exists.
@@ -85,8 +86,7 @@ function useLocalStorage(key, initialValue, isBoolean = false) {
     const eventKey = event.key || event.detail?.key
     const eventValue = event.newValue || event.detail?.newValue
 
-    if (eventKey === key)
-      setValue(isBoolean ? JSON.parse(eventValue) : eventValue)
+    if (eventKey === key) setValue(parserFn(eventValue))
   }
 
   useEventListener(LOCAL_STORAGE_KEY, handleStorageChange)

--- a/components/react/hooks/src/useLocalStorage/index.js
+++ b/components/react/hooks/src/useLocalStorage/index.js
@@ -14,7 +14,7 @@ const hasWindow = () => typeof window !== 'undefined'
  * @param parserFn func - Function applied in the listener when changing a local storage value manually in the browser
  * @returns {UseLocalStorageResult}
  */
-function useLocalStorage(key, initialValue, parserFn = value => value) {
+function useLocalStorage(key, initialValue, {parserFn = value => value} = {}) {
   /**
    * The loadStoredValue retrieve the stored value
    * from the localStorage if it exists.


### PR DESCRIPTION
# Overview
This hook implements a listener that waits until the local storage is manually changed through the browser. When this happen, it triggers a function to set the new value to the state of the hook.

In a previous implementation of this hook, we noticed that if the value that we want to save in the local storage tends to be a boolean, the `newValue` property of the listener's event, is always going to be a `String`. So if we change manually the LS to false, the `newValue` is going to be `"false"`. With this, the new state instead of a boolean `false` would be `"false"` and can lead to confusion when checking the value in the code.

This can happen also with other JSON string types (Objects, numbers...)

# Solution
To solve this, we suggest adding a parser function argument that can ensure the correct parsing method of the `newValue` and also can help to validate what the user change manually to avoid security issues.

By default, if this function is not defined as an argument in the hook, will return the same value as retrieved in the event.