### PR TITLE
fix(components/form/builder): pickers autocomplete/dropdown are shown…

### DIFF
--- a/components/form/builder/.npmignore
+++ b/components/form/builder/.npmignore
@@ -1,1 +1,2 @@
 src
+mocks

--- a/components/form/builder/demo/BasicFormSection.js
+++ b/components/form/builder/demo/BasicFormSection.js
@@ -1,0 +1,57 @@
+import {useState} from 'react'
+
+import FormBuilder from 'components/form/builder/src/index.js'
+import {checkConstraintsFactory} from 'components/form/builder/src/Standard/index'
+import PropTypes from 'prop-types'
+
+import {FORM_BUILDER_SELECT_FIELD_MOCK} from '../mocks/index.js'
+
+export default function BasicFormSection({
+  json: formJsonProp = FORM_BUILDER_SELECT_FIELD_MOCK,
+  errors: errorsProp = {},
+  ...restProps
+}) {
+  const [json] = useState(formJsonProp)
+  const [stateFields, setStateFields] = useState({})
+  const [errors, setErrors] = useState(errorsProp)
+
+  const handleFormSubmit = e => {
+    e.preventDefault()
+
+    // Get form errors to print it
+    const newNativeErrors = checkConstraintsFactory(json, 'es-ES')({all: true})
+
+    if (newNativeErrors) {
+      setErrors(newNativeErrors)
+    }
+  }
+
+  return (
+    <section style={{padding: '16px', marginBottom: '16px'}}>
+      <form onSubmit={handleFormSubmit} noValidate>
+        <FormBuilder
+          errors={errors}
+          json={json}
+          onChange={fields => setStateFields(fields)}
+          {...restProps}
+        />
+        <button>Submit</button>
+      </form>
+      <pre
+        style={{
+          maxHeight: '400px',
+          border: '1px solid',
+          margin: '5px 5px',
+          overflowY: 'scroll'
+        }}
+      >
+        <code>{JSON.stringify(stateFields, null, 2)}</code>
+      </pre>
+    </section>
+  )
+}
+
+BasicFormSection.propTypes = {
+  json: PropTypes.object,
+  errors: PropTypes.object
+}

--- a/components/form/builder/demo/context.js
+++ b/components/form/builder/demo/context.js
@@ -1,0 +1,17 @@
+import {stats} from '@s-ui/js/lib/ua-parser'
+const browser = stats(window.navigator.userAgent)
+
+export default () => ({
+  default: {
+    browser
+  },
+  mobile: {
+    browser: {isDesktop: false, isMobile: true, isTablet: false}
+  },
+  tablet: {
+    browser: {isDesktop: false, isMobile: false, isTablet: false}
+  },
+  desktop: {
+    browser: {isDesktop: true, isMobile: false, isTablet: false}
+  }
+})

--- a/components/form/builder/demo/index.js
+++ b/components/form/builder/demo/index.js
@@ -3,20 +3,23 @@ import {useState} from 'react'
 import FormBuilder from 'components/form/builder/src/index.js'
 
 import {json as fakeJSON} from './formList'
-// import {json as fakeJSON} from './formCCAA'
-// import {categories as fakeJSON} from './form'
 import {formPTACar as fakeFormPTACarJSON} from './formPTACar'
 import {formPTAMiscLite as fakeFormPTAMiscLite} from './formPTAMiscLite'
 import {formPTAMotor as fakeFormPTAMotor} from './formPTAMotor'
 import {initValues as fakeInit} from './initvalue'
+import BasicFormSection from './BasicFormSection.js'
 
 const DemoFormBuilder = () => {
   const [stateFields, setStateFields] = useState({})
   const [stateFieldsPTACar, setStateFieldsPTACar] = useState({})
   const [stateFieldsPTAMotor, setStateFieldsPTAMotor] = useState({})
   const [stateFieldsPTAMiscLite, setStateFieldsPTAMiscLite] = useState({})
+
   return (
     <div className="DemoFormBuilder">
+      <h1>Form / Builder</h1>
+      <h2>Basic form example</h2>
+      <BasicFormSection />
       <h1>Filters FormBuilder</h1>
       <div style={{padding: '20px'}}>
         <FormBuilder

--- a/components/form/builder/demo/index.scss
+++ b/components/form/builder/demo/index.scss
@@ -3,4 +3,5 @@
 @import '../src/index.scss';
 
 .DemoFormBuilder {
+    background-color: #FFF;
 }

--- a/components/form/builder/demo/index.scss
+++ b/components/form/builder/demo/index.scss
@@ -1,0 +1,6 @@
+@import '~@s-ui/theme/lib/utils';
+
+@import '../src/index.scss';
+
+.DemoFormBuilder {
+}

--- a/components/form/builder/demo/index.scss
+++ b/components/form/builder/demo/index.scss
@@ -3,5 +3,5 @@
 @import '../src/index.scss';
 
 .DemoFormBuilder {
-    background-color: #FFF;
+  background-color: #fff;
 }

--- a/components/form/builder/demo/package.json
+++ b/components/form/builder/demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "demo",
+  "name": "@s-ui/react-form-builder-demo",
   "version": "1.0.0",
   "private": true,
   "description": "",

--- a/components/form/builder/demo/playground
+++ b/components/form/builder/demo/playground
@@ -1,1 +1,0 @@
-return (<FormBuilder />)

--- a/components/form/builder/mocks/index.js
+++ b/components/form/builder/mocks/index.js
@@ -1,0 +1,53 @@
+export const FORM_BUILDER_SELECT_FIELD_MOCK = {
+  form: {
+    id: 'milanuncios-insert-car-v3',
+    type: 'group',
+    label: 'Publica tu anuncio',
+    actionlabel: 'Publicar',
+    fields: [
+      {
+        id: 'hasEnergyCertificate',
+        hint: '¿Tienes certificado energético?',
+        type: 'picker',
+        tabIndex: 0,
+        display: 'dropdown',
+        required: true,
+        datalist: [
+          {
+            value: 'true',
+            text: 'Sí, tengo el certificado energético'
+          },
+          {value: 'false', text: 'Está en trámite'}
+        ],
+        constraints: [
+          {
+            property: {notnull: ''},
+            message: 'Este campo es obligatorio'
+          }
+        ]
+      },
+      {
+        id: 'searchACountry',
+        hint: 'Busca un país',
+        type: 'picker',
+        tabIndex: 0,
+        display: 'autocomplete',
+        required: true,
+        datalist: [
+          {
+            value: 'spain',
+            text: 'España'
+          },
+          {value: 'france', text: 'Francia'}
+        ],
+        constraints: [
+          {
+            property: {notnull: ''},
+            message: 'Este campo es obligatorio'
+          }
+        ]
+      }
+    ],
+    rules: {}
+  }
+}

--- a/components/form/builder/mocks/index.js
+++ b/components/form/builder/mocks/index.js
@@ -51,3 +51,58 @@ export const FORM_BUILDER_SELECT_FIELD_MOCK = {
     rules: {}
   }
 }
+
+export const FORM_BUILDER_SELECT_FIELD_WITH_DISABLED_MOCK = {
+  form: {
+    id: 'milanuncios-insert-car-v3',
+    type: 'group',
+    label: 'Publica tu anuncio',
+    actionlabel: 'Publicar',
+    fields: [
+      {
+        id: 'hasEnergyCertificate',
+        hint: '¿Tienes certificado energético?',
+        type: 'picker',
+        tabIndex: 0,
+        display: 'dropdown',
+        required: true,
+        disabled: true,
+        datalist: [
+          {
+            value: 'true',
+            text: 'Sí, tengo el certificado energético'
+          },
+          {value: 'false', text: 'Está en trámite'}
+        ],
+        constraints: [
+          {
+            property: {notnull: ''},
+            message: 'Este campo es obligatorio'
+          }
+        ]
+      },
+      {
+        id: 'searchACountry',
+        hint: 'Busca un país',
+        type: 'picker',
+        tabIndex: 0,
+        display: 'autocomplete',
+        required: true,
+        datalist: [
+          {
+            value: 'spain',
+            text: 'España'
+          },
+          {value: 'france', text: 'Francia'}
+        ],
+        constraints: [
+          {
+            property: {notnull: ''},
+            message: 'Este campo es obligatorio'
+          }
+        ]
+      }
+    ],
+    rules: {}
+  }
+}

--- a/components/form/builder/src/Standard/index.js
+++ b/components/form/builder/src/Standard/index.js
@@ -95,24 +95,6 @@ const checkConstraintsFromField = (field, locale) => {
     )
       errorMessages = [...errorMessages, textAreaHasMinLength.message]
   }
-  // custom validation: since SUI select and autocomplete add disabled and readOnly props to input the default validity function marks allways as valid the field
-  if (
-    field.type === FIELDS.PICKER &&
-    (field.display === DISPLAYS[FIELDS.PICKER].AUTOCOMPLETE ||
-      field.display === DISPLAYS[FIELDS.PICKER].DROPDOWN ||
-      field.display === '')
-  ) {
-    const pickerValue = elementNode?.value
-    const pickerShouldNotBeNullConstraint = field.constraints?.find(
-      constraint => constraint.property?.notnull === ''
-    )
-    if (pickerShouldNotBeNullConstraint && !pickerValue) {
-      errorMessages = [
-        pickerShouldNotBeNullConstraint.message,
-        ...errorMessages
-      ]
-    }
-  }
 
   // custom validation: pattern constraint in html input (type=checkbox) is not natively supported, need to handle it manually
   if (
@@ -170,6 +152,7 @@ const checkConstraintsFromField = (field, locale) => {
       errorMessages = [...errorMessages, inputHasMax.message]
     }
   }
+
   return errorMessages
 }
 

--- a/components/form/builder/test/index.test.js
+++ b/components/form/builder/test/index.test.js
@@ -1,22 +1,70 @@
-/*
- * Remember: YOUR COMPONENT IS DEFINED GLOBALLY
- * */
-
 /* eslint react/jsx-no-undef:0 */
+/* eslint no-undef:0 */
 
-// import React from 'react'
-// import {render} from '@testing-library/react'
+import ReactDOM from 'react-dom'
 
 import chai, {expect} from 'chai'
 import chaiDOM from 'chai-dom'
 
+import userEvent from '@testing-library/user-event'
+
+import BasicFormSection from '../demo/BasicFormSection.js'
+import {FORM_BUILDER_SELECT_FIELD_MOCK} from '../mocks/index.js'
+import FormBuilder from '../src/index.js'
+import {checkConstraintsFactory} from '../src/Standard/index.js'
+
 chai.use(chaiDOM)
 
-describe.skip('form/builder', () => {
-  it('Render', () => {
-    // Example TO BE DELETED!!!!
-    // const {getByRole} = render(<AtomButton>HOLA</AtomButton>)
-    // expect(getByRole('button')).to.have.text('HOLA')
-    expect(true).to.be.eql(false)
+describe('form/builder', () => {
+  const WrappedFormComponent = props => <BasicFormSection {...props} />
+
+  const setup = setupEnvironment(FormBuilder)
+  const setupForm = setupEnvironment(WrappedFormComponent)
+
+  it('should render without crashing', () => {
+    // Given
+    const props = {
+      json: FORM_BUILDER_SELECT_FIELD_MOCK
+    }
+
+    // When
+    const Component = <FormBuilder {...props} />
+
+    // Then
+    const div = document.createElement('div')
+    ReactDOM.render(Component, div)
+    ReactDOM.unmountComponentAtNode(div)
+  })
+
+  it('should not render null', () => {
+    // Given
+    const props = {
+      json: FORM_BUILDER_SELECT_FIELD_MOCK
+    }
+
+    // When
+    const {container} = setup(props)
+
+    // Then
+    expect(container.innerHTML).to.be.a('string')
+    expect(container.innerHTML).to.not.have.lengthOf(0)
+  })
+
+  it('should render all required message errors when user clicks without fill any input', async () => {
+    const props = {
+      json: FORM_BUILDER_SELECT_FIELD_MOCK,
+      errors: checkConstraintsFactory(
+        FORM_BUILDER_SELECT_FIELD_MOCK,
+        'es-ES'
+      )({all: true})
+    }
+
+    const {queryAllByText, getByText} = setupForm(props)
+
+    const button = getByText(/Submit/)
+    await userEvent.click(button)
+    const requiredFields = queryAllByText('Este campo es obligatorio')
+
+    expect(requiredFields).to.have.lengthOf(2)
   })
 })

--- a/components/form/builder/test/index.test.js
+++ b/components/form/builder/test/index.test.js
@@ -9,7 +9,10 @@ import chaiDOM from 'chai-dom'
 import userEvent from '@testing-library/user-event'
 
 import BasicFormSection from '../demo/BasicFormSection.js'
-import {FORM_BUILDER_SELECT_FIELD_MOCK} from '../mocks/index.js'
+import {
+  FORM_BUILDER_SELECT_FIELD_MOCK,
+  FORM_BUILDER_SELECT_FIELD_WITH_DISABLED_MOCK
+} from '../mocks/index.js'
 import FormBuilder from '../src/index.js'
 import {checkConstraintsFactory} from '../src/Standard/index.js'
 
@@ -50,21 +53,41 @@ describe('form/builder', () => {
     expect(container.innerHTML).to.not.have.lengthOf(0)
   })
 
-  it('should render all required message errors when user clicks without fill any input', async () => {
-    const props = {
-      json: FORM_BUILDER_SELECT_FIELD_MOCK,
-      errors: checkConstraintsFactory(
-        FORM_BUILDER_SELECT_FIELD_MOCK,
-        'es-ES'
-      )({all: true})
-    }
+  describe('should display correct error messages', () => {
+    it('when user clicks without fill any input', async () => {
+      const props = {
+        json: FORM_BUILDER_SELECT_FIELD_MOCK,
+        errors: checkConstraintsFactory(
+          FORM_BUILDER_SELECT_FIELD_MOCK,
+          'es-ES'
+        )({all: true})
+      }
 
-    const {queryAllByText, getByText} = setupForm(props)
+      const {queryAllByText, getByText} = setupForm(props)
 
-    const button = getByText(/Submit/)
-    await userEvent.click(button)
-    const requiredFields = queryAllByText('Este campo es obligatorio')
+      const button = getByText(/Submit/)
+      await userEvent.click(button)
+      const requiredFields = queryAllByText('Este campo es obligatorio')
 
-    expect(requiredFields).to.have.lengthOf(2)
+      expect(requiredFields).to.have.lengthOf(2)
+    })
+
+    it('when we aa required field is disabled', async () => {
+      const props = {
+        json: FORM_BUILDER_SELECT_FIELD_WITH_DISABLED_MOCK,
+        errors: checkConstraintsFactory(
+          FORM_BUILDER_SELECT_FIELD_WITH_DISABLED_MOCK,
+          'es-ES'
+        )({all: true})
+      }
+
+      const {queryAllByText, getByText} = setupForm(props)
+
+      const button = getByText(/Submit/)
+      await userEvent.click(button)
+      const requiredFields = queryAllByText('Este campo es obligatorio')
+
+      expect(requiredFields).to.have.lengthOf(1)
+    })
   })
 })

--- a/components/form/builder/test/index.test.js
+++ b/components/form/builder/test/index.test.js
@@ -53,41 +53,39 @@ describe('form/builder', () => {
     expect(container.innerHTML).to.not.have.lengthOf(0)
   })
 
-  describe('should display correct error messages', () => {
-    it('when user clicks without fill any input', async () => {
-      const props = {
-        json: FORM_BUILDER_SELECT_FIELD_MOCK,
-        errors: checkConstraintsFactory(
-          FORM_BUILDER_SELECT_FIELD_MOCK,
-          'es-ES'
-        )({all: true})
-      }
+  it('should display error validation message when field is required', async () => {
+    const props = {
+      json: FORM_BUILDER_SELECT_FIELD_MOCK,
+      errors: checkConstraintsFactory(
+        FORM_BUILDER_SELECT_FIELD_MOCK,
+        'es-ES'
+      )({all: true})
+    }
 
-      const {queryAllByText, getByText} = setupForm(props)
+    const {queryAllByText, getByText} = setupForm(props)
 
-      const button = getByText(/Submit/)
-      await userEvent.click(button)
-      const requiredFields = queryAllByText('Este campo es obligatorio')
+    const button = getByText(/Submit/)
+    await userEvent.click(button)
+    const requiredFields = queryAllByText('Este campo es obligatorio')
 
-      expect(requiredFields).to.have.lengthOf(2)
-    })
+    expect(requiredFields).to.have.lengthOf(2)
+  })
 
-    it('when we aa required field is disabled', async () => {
-      const props = {
-        json: FORM_BUILDER_SELECT_FIELD_WITH_DISABLED_MOCK,
-        errors: checkConstraintsFactory(
-          FORM_BUILDER_SELECT_FIELD_WITH_DISABLED_MOCK,
-          'es-ES'
-        )({all: true})
-      }
+  it('should not display error validation message when field is disabled', async () => {
+    const props = {
+      json: FORM_BUILDER_SELECT_FIELD_WITH_DISABLED_MOCK,
+      errors: checkConstraintsFactory(
+        FORM_BUILDER_SELECT_FIELD_WITH_DISABLED_MOCK,
+        'es-ES'
+      )({all: true})
+    }
 
-      const {queryAllByText, getByText} = setupForm(props)
+    const {queryAllByText, getByText} = setupForm(props)
 
-      const button = getByText(/Submit/)
-      await userEvent.click(button)
-      const requiredFields = queryAllByText('Este campo es obligatorio')
+    const button = getByText(/Submit/)
+    await userEvent.click(button)
+    const requiredFields = queryAllByText('Este campo es obligatorio')
 
-      expect(requiredFields).to.have.lengthOf(1)
-    })
+    expect(requiredFields).to.have.lengthOf(1)
   })
 })


### PR DESCRIPTION
## Form/Builder 
`❓ Ask`

**TASK**: NO TASK ID

### Types of changes

- [x] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📷 Demo
- [x] 🧪 Test

### Description, Motivation and Context

#### Context

As you can see at the image attached, the `Marca` field has 2 error messages "Debes seleccionar una marca". ~(⚠️ Spoiler: That's the 🐛)~ . This field is a `type=Picker display=Dropdown` field. But wait, if the `Modelo` field is also a `type=Picker display=Dropdown`, why has not 2 errors also? The answer is.... because it is disabled!

Beeing more concise, [at those lines](https://github.com/SUI-Components/adevinta-spain-components/blob/master/components/form/builder/src/Standard/index.js#L61-L77), our `checkConstraintsFromField` method is validating our DOM Element and seeing the native [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState). Those lines will tell us if the DOM Element has errors such as `badInput`, `valueMissing` and so on. 

Continuing [with those other lines](https://github.com/SUI-Components/adevinta-spain-components/blob/master/components/form/builder/src/Standard/index.js#L98-L115), here we have a custom edge validation for `type=Picker display=Dropdown` fields. If we read the comment line... we will understand why we need this: `// custom validation: since SUI select and autocomplete add disabled and readOnly props to input the default validity function marks allways as valid the field` 

At some point in 2022, the internal structure of MoleculeSelect had a input field with disabled / readonly attribute causing us to create a manual validation at `form/builder`. That structure has been changed/improved and now the initial validation (the native one) is checking well the validity of this `type=Picker display=Dropdown` fields ; and currently we don't need the second validation. 

And that's why the `Marca` field has 2 errors (the native one and our custom edge case for pickers) and the `Modelo` only has one, because was disabled. 
 
#### Proposal
I propose to remove our custom edge validation in favour of native one. I thought also to clean the array to prevent duplicated error messages but I think this is the better and clean solution.

### Screenshots - Animations

![Image of Marca field with two error messages and Modelo field only with one](https://user-images.githubusercontent.com/3933098/210343002-b68c2669-c7e5-4d4b-bf16-8706c746d077.png)

