### PR TITLE
feat(components/login/passwordReset): Add domain

### DIFF
--- a/components/login/passwordReset/package.json
+++ b/components/login/passwordReset/package.json
@@ -8,6 +8,10 @@
     "build:js": "babel --presets sui ./src --out-dir ./lib",
     "build:styles": "cpx './src/**/*.scss' ./lib"
   },
+  "dependencies": {
+    "@s-ui/decorators": "3",
+    "@s-ui/domain": "2"
+  },
   "peerDependencies": {
     "@s-ui/theme": "8"
   },

--- a/components/login/passwordReset/src/context.js
+++ b/components/login/passwordReset/src/context.js
@@ -2,11 +2,13 @@ import {createContext} from 'react'
 
 import PropTypes from 'prop-types'
 
+import Domain from './domain/index.js'
+
 export const PasswordResetContext = createContext()
 
 const PasswordResetProvider = ({children}) => {
   const value = {
-    domain: null,
+    domain: new Domain(),
     i18n: null
   }
   return (

--- a/components/login/passwordReset/src/domain/config.js
+++ b/components/login/passwordReset/src/domain/config.js
@@ -1,0 +1,30 @@
+export default class Config {
+  /**
+   * @constructor
+   * @param {Object} deps
+   * @param {String} deps.appName
+   */
+  constructor() {
+    this._config = {}
+  }
+
+  /**
+   * @method
+   * @param {String} key
+   * @return {*}
+   */
+  get(key) {
+    return this._config[key]
+  }
+
+  /**
+   * @method
+   * @param {String} key
+   * @param {*} value
+   * @return {*}
+   */
+  set(key, value) {
+    this._config[key] = value
+    return this
+  }
+}

--- a/components/login/passwordReset/src/domain/index.js
+++ b/components/login/passwordReset/src/domain/index.js
@@ -1,0 +1,18 @@
+import {EntryPointFactory} from '@s-ui/domain'
+
+import Config from './config.js'
+
+/* const importActivityFactory = () => import('./activity/UseCases/factory.js')
+
+const activityUseCases = {
+  get_account_activity_use_case: [
+    importActivityFactory,
+    'getAccountActivityUseCase'
+  ]
+} */
+
+const useCases = {
+  // ...activityUseCases
+}
+
+export default EntryPointFactory({config: new Config(), useCases})


### PR DESCRIPTION
Add domain to the `login/passwordReset` component.

# Why this component needs a domain inside it?

It will contain and manage all logic related with the password reset flow.
By initializing a single component and specifying some basic configuration props, and app will be able to load all the login interface in a fully-working way.

In order to make this component as similar to our apps as possible, we are adopting sui domain inside it, to design and implement all the logic.