### PR TITLE
feat(components/login/passwordReset): Mock endpoint with sui-mock

### DIFF
--- a/components/login/passwordReset/package.json
+++ b/components/login/passwordReset/package.json
@@ -13,6 +13,9 @@
     "@s-ui/domain": "2",
     "@s-ui/i18n": "1"
   },
+  "devDependencies": {
+    "@s-ui/mockmock": "1"
+  },
   "peerDependencies": {
     "@s-ui/theme": "8"
   },

--- a/components/login/passwordReset/src/domain/password/Repositories/HTTPPasswordRepository.js
+++ b/components/login/passwordReset/src/domain/password/Repositories/HTTPPasswordRepository.js
@@ -12,17 +12,12 @@ export class HTTPPasswordRepository extends PasswordRepository {
   @inlineError
   resetPassword({resetPasswordRequest}) {
     const email = resetPasswordRequest.getEmail()
-    // WIP, just to pass tests
-    if (email !== 'something-wrong') return Promise.resolve(true)
-
-    return Promise.reject(new Error('Unhandled error ocurred'))
-
-    /* const path = this._config.get('RESET_PASSWORD_ENDPOINT')
+    const path = this._config.get('RESET_PASSWORD_ENDPOINT')
     return this._fetcher
       .post({path, params: {email}})
-      .then(response => response.data)
+      .then(() => true)
       .catch(() => {
         throw new Error('Unhandled error ocurred')
-      }) */
+      })
   }
 }

--- a/components/login/passwordReset/src/domain/test/password/ResetPasswordUseCaseSpec.js
+++ b/components/login/passwordReset/src/domain/test/password/ResetPasswordUseCaseSpec.js
@@ -2,24 +2,47 @@
 /* eslint no-undef:0 */
 import {expect} from 'chai'
 
+import Mocker from '@s-ui/mockmock/lib/http'
+
 import Domain from '../../index.js'
 
 describe('[Domain] ResetPasswordUseCase', () => {
   const domain = new Domain()
   const useCase = domain.get('reset_password_use_case')
+  const mocker = new Mocker()
+
+  beforeEach(() => {
+    mocker.create()
+  })
+
+  afterEach(() => {
+    mocker.restore()
+  })
 
   it('should successfully start the password reset process', async () => {
-    const [error, result] = await useCase.execute({
-      email: 'someone@adevinta.com'
-    })
+    const requestBody = {email: 'someone@adevinta.com'}
+
+    mocker
+      .httpMock('http://localhost/')
+      .post('v1/ecg/password-reset', requestBody)
+      .reply(null, 204)
+
+    const [error, result] = await useCase.execute(requestBody)
     expect(error).to.be.null
     expect(result).to.eql(true)
   })
 
   it('should return an exception if something goes wrong', async () => {
-    const [error, result] = await useCase.execute({
+    const requestBody = {
       email: 'something-wrong'
-    })
+    }
+
+    mocker
+      .httpMock('http://localhost/')
+      .post('v1/ecg/password-reset', requestBody)
+      .reply(null, 400)
+
+    const [error, result] = await useCase.execute(requestBody)
     expect(error).to.not.be.null
     expect(error.toString()).to.eql('Error: Unhandled error ocurred')
     expect(result).to.be.null


### PR DESCRIPTION
Mock the reset password endpoint and make the use case fully functional.

We'll use sui-mockmock to make the dev process more easy, because using the new sui-mock library may require to modify ci steps to ensure msw is properly executed during the test running.