### PR TITLE
feat(components/login/passwordReset): Add more semantic errors

### DIFF
--- a/components/login/passwordReset/src/domain/password/Errors/PasswordError.js
+++ b/components/login/passwordReset/src/domain/password/Errors/PasswordError.js
@@ -1,0 +1,5 @@
+export class PasswordError extends Error {
+  constructor(msg) {
+    super(`[PasswordError] ${msg}`)
+  }
+}

--- a/components/login/passwordReset/src/domain/password/Errors/factory.js
+++ b/components/login/passwordReset/src/domain/password/Errors/factory.js
@@ -1,0 +1,4 @@
+import {PasswordError} from './PasswordError.js'
+export class PasswordErrorsFactory {
+  static passwordError = msg => new PasswordError(msg)
+}

--- a/components/login/passwordReset/src/domain/password/Repositories/HTTPPasswordRepository.js
+++ b/components/login/passwordReset/src/domain/password/Repositories/HTTPPasswordRepository.js
@@ -19,7 +19,7 @@ export class HTTPPasswordRepository extends PasswordRepository {
       .post({path, params: {password, token}})
       .then(() => true)
       .catch(() => {
-        throw this._passwordError('Unhandled error ocurred')
+        throw this._passwordError('Unhandled error occured')
       })
   }
 
@@ -31,7 +31,7 @@ export class HTTPPasswordRepository extends PasswordRepository {
       .post({path, params: {email}})
       .then(() => true)
       .catch(() => {
-        throw this._passwordError('Unhandled error ocurred')
+        throw this._passwordError('Unhandled error occured')
       })
   }
 }

--- a/components/login/passwordReset/src/domain/password/Repositories/HTTPPasswordRepository.js
+++ b/components/login/passwordReset/src/domain/password/Repositories/HTTPPasswordRepository.js
@@ -3,10 +3,11 @@ import {inlineError} from '@s-ui/decorators'
 import {PasswordRepository} from './PasswordRepository.js'
 
 export class HTTPPasswordRepository extends PasswordRepository {
-  constructor({config, fetcher}) {
+  constructor({config, fetcher, passwordError}) {
     super()
     this._config = config
     this._fetcher = fetcher
+    this._passwordError = passwordError
   }
 
   @inlineError
@@ -18,7 +19,7 @@ export class HTTPPasswordRepository extends PasswordRepository {
       .post({path, params: {password, token}})
       .then(() => true)
       .catch(() => {
-        throw new Error('Unhandled error ocurred')
+        throw this._passwordError('Unhandled error ocurred')
       })
   }
 
@@ -30,7 +31,7 @@ export class HTTPPasswordRepository extends PasswordRepository {
       .post({path, params: {email}})
       .then(() => true)
       .catch(() => {
-        throw new Error('Unhandled error ocurred')
+        throw this._passwordError('Unhandled error ocurred')
       })
   }
 }

--- a/components/login/passwordReset/src/domain/password/Repositories/HTTPPasswordRepository.js
+++ b/components/login/passwordReset/src/domain/password/Repositories/HTTPPasswordRepository.js
@@ -19,7 +19,7 @@ export class HTTPPasswordRepository extends PasswordRepository {
       .post({path, params: {password, token}})
       .then(() => true)
       .catch(() => {
-        throw this._passwordError('Unhandled error occured')
+        throw this._passwordError('Unhandled error occurred')
       })
   }
 
@@ -31,7 +31,7 @@ export class HTTPPasswordRepository extends PasswordRepository {
       .post({path, params: {email}})
       .then(() => true)
       .catch(() => {
-        throw this._passwordError('Unhandled error occured')
+        throw this._passwordError('Unhandled error occurred')
       })
   }
 }

--- a/components/login/passwordReset/src/domain/password/Repositories/factory.js
+++ b/components/login/passwordReset/src/domain/password/Repositories/factory.js
@@ -1,10 +1,12 @@
 import FetcherFactory from '../../fetcher/factory.js'
+import {PasswordErrorsFactory} from '../Errors/factory.js'
 import {HTTPPasswordRepository} from './HTTPPasswordRepository.js'
 
 export class PasswordRepositoriesFactory {
   static hTTPPasswordRepository = ({config}) =>
     new HTTPPasswordRepository({
       config,
-      fetcher: FetcherFactory.unauthenticatedFetcher({config})
+      fetcher: FetcherFactory.unauthenticatedFetcher({config}),
+      passwordError: PasswordErrorsFactory.passwordError
     })
 }

--- a/components/login/passwordReset/src/domain/test/password/ChangePasswordUseCaseSpec.js
+++ b/components/login/passwordReset/src/domain/test/password/ChangePasswordUseCaseSpec.js
@@ -42,7 +42,9 @@ describe('[Domain] ChangePasswordUseCase', () => {
 
     const [error, result] = await useCase.execute(requestBody)
     expect(error).to.not.be.null
-    expect(error.toString()).to.eql('Error: Unhandled error ocurred')
+    expect(error.toString()).to.eql(
+      'Error: [PasswordError] Unhandled error ocurred'
+    )
     expect(result).to.be.null
   })
 })

--- a/components/login/passwordReset/src/domain/test/password/ChangePasswordUseCaseSpec.js
+++ b/components/login/passwordReset/src/domain/test/password/ChangePasswordUseCaseSpec.js
@@ -5,6 +5,7 @@ import {expect} from 'chai'
 import Mocker from '@s-ui/mockmock/lib/http'
 
 import Domain from '../../index.js'
+import {PasswordError} from '../../password/Errors/PasswordError.js'
 
 describe('[Domain] ChangePasswordUseCase', () => {
   const domain = new Domain()
@@ -42,6 +43,7 @@ describe('[Domain] ChangePasswordUseCase', () => {
 
     const [error, result] = await useCase.execute(requestBody)
     expect(error).to.not.be.null
+    expect(error).to.be.an.instanceof(PasswordError)
     expect(error.toString()).to.eql(
       'Error: [PasswordError] Unhandled error occurred'
     )

--- a/components/login/passwordReset/src/domain/test/password/ChangePasswordUseCaseSpec.js
+++ b/components/login/passwordReset/src/domain/test/password/ChangePasswordUseCaseSpec.js
@@ -43,7 +43,7 @@ describe('[Domain] ChangePasswordUseCase', () => {
     const [error, result] = await useCase.execute(requestBody)
     expect(error).to.not.be.null
     expect(error.toString()).to.eql(
-      'Error: [PasswordError] Unhandled error ocurred'
+      'Error: [PasswordError] Unhandled error occurred'
     )
     expect(result).to.be.null
   })

--- a/components/login/passwordReset/src/domain/test/password/ResetPasswordUseCaseSpec.js
+++ b/components/login/passwordReset/src/domain/test/password/ResetPasswordUseCaseSpec.js
@@ -5,6 +5,7 @@ import {expect} from 'chai'
 import Mocker from '@s-ui/mockmock/lib/http'
 
 import Domain from '../../index.js'
+import {PasswordError} from '../../password/Errors/PasswordError.js'
 
 describe('[Domain] ResetPasswordUseCase', () => {
   const domain = new Domain()
@@ -44,6 +45,7 @@ describe('[Domain] ResetPasswordUseCase', () => {
 
     const [error, result] = await useCase.execute(requestBody)
     expect(error).to.not.be.null
+    expect(error).to.be.an.instanceof(PasswordError)
     expect(error.toString()).to.eql(
       'Error: [PasswordError] Unhandled error occurred'
     )

--- a/components/login/passwordReset/src/domain/test/password/ResetPasswordUseCaseSpec.js
+++ b/components/login/passwordReset/src/domain/test/password/ResetPasswordUseCaseSpec.js
@@ -44,7 +44,9 @@ describe('[Domain] ResetPasswordUseCase', () => {
 
     const [error, result] = await useCase.execute(requestBody)
     expect(error).to.not.be.null
-    expect(error.toString()).to.eql('Error: Unhandled error ocurred')
+    expect(error.toString()).to.eql(
+      'Error: [PasswordError] Unhandled error ocurred'
+    )
     expect(result).to.be.null
   })
 })

--- a/components/login/passwordReset/src/domain/test/password/ResetPasswordUseCaseSpec.js
+++ b/components/login/passwordReset/src/domain/test/password/ResetPasswordUseCaseSpec.js
@@ -45,7 +45,7 @@ describe('[Domain] ResetPasswordUseCase', () => {
     const [error, result] = await useCase.execute(requestBody)
     expect(error).to.not.be.null
     expect(error.toString()).to.eql(
-      'Error: [PasswordError] Unhandled error ocurred'
+      'Error: [PasswordError] Unhandled error occurred'
     )
     expect(result).to.be.null
   })


### PR DESCRIPTION
# Context

We're implementing the `login/passwordReset` component. This component will allow any web-app to render the password reset interface in a fully functional way, in order to adopt the cross login system ensuring the best developer experience possible.

# Changes

Stop using standard errors and wrap them on more semantic error class.