### PR TITLE
feat(components/login/passwordReset): Display an error if token is expired

### DIFF
--- a/components/login/passwordReset/package.json
+++ b/components/login/passwordReset/package.json
@@ -17,7 +17,8 @@
     "@s-ui/react-molecule-notification": "1",
     "@s-ui/react-molecule-progress-steps": "2",
     "@s-ui/react-atom-icon": "1",
-    "@s-ui/react-atom-tooltip": "2"
+    "@s-ui/react-atom-tooltip": "2",
+    "@s-ui/react-hooks": "1"
   },
   "devDependencies": {
     "@s-ui/mockmock": "1"

--- a/components/login/passwordReset/src/components/Form/PasswordChangeForm.js
+++ b/components/login/passwordReset/src/components/Form/PasswordChangeForm.js
@@ -7,6 +7,7 @@ import AtomButton, {
 } from '@s-ui/react-atom-button'
 
 import {BASE_CLASS} from '../../config.js'
+import useDisplayExpiredTokenError from '../../hooks/components/useDisplayExpiredTokenError.js'
 import usePasswordChangeFormState from '../../hooks/components/usePasswordChangeFormState.js'
 import useDomain from '../../hooks/useDomain.js'
 import useGetCurrentToken from '../../hooks/useGetCurrentToken.js'
@@ -20,6 +21,7 @@ const PasswordChangeForm = ({icons}) => {
   const domain = useDomain()
   const {getCurrentToken} = useGetCurrentToken()
   const {token} = getCurrentToken()
+
   const {
     state: {newPassword, repeatPassword, isLoading, notification},
     setNewPassword,
@@ -27,6 +29,8 @@ const PasswordChangeForm = ({icons}) => {
     setNotification,
     setIsLoading
   } = usePasswordChangeFormState()
+
+  useDisplayExpiredTokenError(setNotification)
 
   const handleChange = e => {
     const {value} = e?.target

--- a/components/login/passwordReset/src/hooks/components/useDisplayExpiredTokenError.js
+++ b/components/login/passwordReset/src/hooks/components/useDisplayExpiredTokenError.js
@@ -1,0 +1,21 @@
+import {useMount} from '@s-ui/react-hooks'
+
+import useI18n from '../../hooks/useI18n.js'
+import useGetCurrentToken from '../useGetCurrentToken.js'
+
+const useDisplayExpiredTokenError = setNotification => {
+  const i18n = useI18n()
+  const {getCurrentToken} = useGetCurrentToken()
+  const {isExpired} = getCurrentToken()
+
+  useMount(() => {
+    if (isExpired) {
+      setNotification({
+        text: i18n.t('LOGIN_CROSS.PASSWORD_RESET.STEP_2.ERRORS.EXPIRED_TOKEN'),
+        isError: true
+      })
+    }
+  })
+}
+
+export default useDisplayExpiredTokenError

--- a/components/login/passwordReset/src/literals/es-ES.js
+++ b/components/login/passwordReset/src/literals/es-ES.js
@@ -44,7 +44,9 @@ export default {
             'La contraseña debe contener un mínimo de 8 letras o números',
           INVALID_PASSWORDS: 'Las contraseñas no coinciden.',
           SERVER_ERROR:
-            'Hemos detectado un error. Vuelve a intentarlo en unos minutos.'
+            'Hemos detectado un error. Vuelve a intentarlo en unos minutos.',
+          EXPIRED_TOKEN:
+            'El enlace que has clicado ha expirado. Vuelve a iniciar el proceso para recuperar tu contraseña.'
         },
         SUCCESS: {
           PASSWORD_CHANGED:


### PR DESCRIPTION
# Context

Implementation of a cross component to allow users to reset their password.

# Changes

Display an error if the user accesses to a password change link with an expired token.