### PR TITLE
feat(components/form/builder): pass leftAddon prop

### DIFF
--- a/components/form/builder/src/Select/Default/index.js
+++ b/components/form/builder/src/Select/Default/index.js
@@ -127,6 +127,7 @@ const DefaultSelect = ({
             key={data.value}
             value={data.value}
             description={data.description}
+            leftAddon={data.leftAddon}
           >
             {data.text}
           </MoleculeSelectOption>


### PR DESCRIPTION
Pass leftAddon prop to moleculeSelect to show icons on cochesnet forms:

<img width="338" alt="226593800-9c31ce91-ffa3-4986-ae2d-2aff899bd76c" src="https://user-images.githubusercontent.com/37936498/226958682-314a54a7-62b7-42c0-959b-f49c7719385d.png">
