### PR TITLE
feat(components/form/builder): Add fields status when calling to onInitFieldsLoadEnd

### DIFF
--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -166,7 +166,14 @@ const FormBuilder = ({
         clearTimeout(timerShowSpinner)
         setStateFields(nextFields)
         setStateShowSpinner(false)
-        onInitFieldsLoadEnd()
+
+        const nextStateFieldsObject = useNativeFieldType
+          ? fieldsToObjectNativeTypes(nextFields)
+          : fieldsToObject(nextFields)
+
+        onInitFieldsLoadEnd({
+          ...nextStateFieldsObject
+        })
       })
   }, [allowInitFieldsReload ? initFields : null]) // eslint-disable-line
 


### PR DESCRIPTION
# Context

In CNET PRO we need to set an internal state when we initialize a form with a specific set of initialValues.
Ideally, to ensure the form flow is totally completed, we need to execute the `onChange` method.

# Changes

The `onInitFieldsLoadEnd` is great for us as it executes an event once the initial fields have been loaded.
The only thing we are missing from it, is to have the current form state passed as a param.

This PR introduces a small change to add a parameter to `onInitFieldsLoadEnd`. It should not affect to apps already using it, as it wasn't receiving any parameter until now.