### PR TITLE
Feat/create google maps drawer

### DIFF
--- a/components/map/google/README.md
+++ b/components/map/google/README.md
@@ -69,6 +69,35 @@ const MapGoogleImageExample = () => {
 }
 ```
 
+##### MapDrawer
+
+Utility component to freehand draw on map, as child of `MapGoogle`.
+
+```js
+import MapGoogle from '@s-ui/sui-map-google'
+import MapGoogleDrawer from '@s-ui/sui-map-google/lib/drawer/index.js'
+
+const polylineStyles = {
+  strokeColor: '#2b91c1',
+  strokeOpacity: 0.5,
+  strokeWeight: 4
+}
+
+const MapGoogleAddOnsExample = () => {
+  const handleStopDrawing = ({path}) => console.log(path)
+
+  return (
+    <MapGoogle apiKey="AIzaSyDp7wqS1IyRZCvMMsY2LX2V1TXY4Lh8UGA">
+      <MapGoogleDrawer
+        drawing
+        onStopDrawing={handleStopDrawing}
+        polylineOptions={polylineStyles}
+      />
+    </MapGoogle>
+  )
+}
+```
+
 #### Import the styles (Sass)
 
 ```css

--- a/components/map/google/demo/articles/MapDrawerArticle.js
+++ b/components/map/google/demo/articles/MapDrawerArticle.js
@@ -42,29 +42,22 @@ export default function MapDrawerArticle({apiKey, height, width}) {
           {draw ? 'Stop drawing' : 'Start drawing'}
         </Button>
       </div>
-
-      <div style={{width: '100%', height: '400px'}}>
-        <MapGoogle
-          apiKey={apiKey}
-          height={height}
-          width={width}
-          center={{lat: 40.714728, lng: -73.998672}}
-          isInteractive
-        >
-          {pathLatLangLiteral && (
-            <MapGooglePolygon
-              path={pathLatLangLiteral}
-              options={polygonStyles}
-            />
-          )}
-          <MapGoogleDrawer
-            drawing={draw}
-            onStopDrawing={handleStopDrawing}
-            polylineOptions={polylineStyles}
-          />
-        </MapGoogle>
-      </div>
-
+      <MapGoogle
+        apiKey={apiKey}
+        height={height}
+        width={width}
+        center={{lat: 40.714728, lng: -73.998672}}
+        isInteractive
+      >
+        {pathLatLangLiteral && (
+          <MapGooglePolygon path={pathLatLangLiteral} options={polygonStyles} />
+        )}
+        <MapGoogleDrawer
+          drawing={draw}
+          onStopDrawing={handleStopDrawing}
+          polylineOptions={polylineStyles}
+        />
+      </MapGoogle>
       <textarea
         key={pathLatLangLiteral}
         width={width}

--- a/components/map/google/demo/articles/MapDrawerArticle.js
+++ b/components/map/google/demo/articles/MapDrawerArticle.js
@@ -1,0 +1,88 @@
+import {useState} from 'react'
+
+import MapGoogle, {
+  MapGoogleDrawer,
+  MapGooglePolygon
+} from 'components/map/google/src/index.js'
+import PropTypes from 'prop-types'
+
+import {Button, H1, Text} from '@s-ui/documentation-library'
+
+const className = 'DemoGoogleMapsDrawer'
+
+const polylineStyles = {
+  strokeColor: '#2b91c1',
+  strokeOpacity: 0.5,
+  strokeWeight: 4
+}
+
+const polygonStyles = {
+  ...polylineStyles,
+  fillColor: '#2b91c1'
+}
+
+export default function MapDrawerArticle({apiKey, height, width}) {
+  const [draw, setDraw] = useState(false)
+  const [pathLatLangLiteral, setPathLatLangLiteral] = useState()
+
+  const handleStopDrawing = ({path}) => {
+    setPathLatLangLiteral(path)
+    setDraw(false)
+  }
+
+  return (
+    <div className={className}>
+      <H1>GoogleMapsDrawer</H1>
+      <Text>
+        Google Maps Drawer component to use as children of Map Google component.
+        This should be used to draw freehand shapes on the map.
+      </Text>
+      <div>
+        <Button onClick={() => setDraw(!draw)}>
+          {draw ? 'Stop drawing' : 'Start drawing'}
+        </Button>
+      </div>
+
+      <div style={{width: '100%', height: '400px'}}>
+        <MapGoogle
+          apiKey={apiKey}
+          height={height}
+          width={width}
+          center={{lat: 40.714728, lng: -73.998672}}
+          isInteractive
+        >
+          {pathLatLangLiteral && (
+            <MapGooglePolygon
+              path={pathLatLangLiteral}
+              options={polygonStyles}
+            />
+          )}
+          <MapGoogleDrawer
+            drawing={draw}
+            onStopDrawing={handleStopDrawing}
+            polylineOptions={polylineStyles}
+          />
+        </MapGoogle>
+      </div>
+
+      <textarea
+        key={pathLatLangLiteral}
+        width={width}
+        height="200px"
+        rows="5"
+        readOnly
+        style={{width}}
+      >
+        {`Drawing path: ${JSON.stringify(pathLatLangLiteral)}`}
+      </textarea>
+    </div>
+  )
+}
+
+MapDrawerArticle.displayName = 'MapDrawerArticle'
+
+MapDrawerArticle.propTypes = {
+  apiKey: PropTypes.string,
+  height: PropTypes.number,
+  width: PropTypes.number
+}

--- a/components/map/google/demo/index.js
+++ b/components/map/google/demo/index.js
@@ -15,6 +15,7 @@ import {
 import MapAddOnsArticle from './articles/MapAddOnsArticle.js'
 import MapArticle from './articles/MapArticle.js'
 import MapCustomUIArticle from './articles/MapCustomUIArticle.js'
+import MapDrawerArticle from './articles/MapDrawerArticle.js'
 import MapImageArticle from './articles/MapImageArticle.js'
 
 const className = 'DemoMapGoogle'
@@ -57,22 +58,29 @@ export default () => {
         />
       </Box>
 
-      <MapArticle
+      {/* <MapArticle
         apiKey={apiKey}
         key={`${apiKey}-MapArticle`}
         height={600}
         width={600}
-      />
+      /> */}
 
-      <MapImageArticle apiKey={apiKey} height={600} width={600} />
+      {/* <MapImageArticle apiKey={apiKey} height={600} width={600} />
 
-      <MapAddOnsArticle apiKey={apiKey} key={`${apiKey}-MapAddOnsArticle`} />
+      <MapAddOnsArticle apiKey={apiKey} key={`${apiKey}-MapAddOnsArticle`} /> */}
 
-      <MapCustomUIArticle
+      {/* <MapCustomUIArticle
         apiKey={apiKey}
         key={`${apiKey}-MapCustomUIArticle`}
         height={600}
         width={600}
+      /> */}
+
+      <MapDrawerArticle
+        apiKey={apiKey}
+        // height={600}
+        // width={600}
+        key={`${apiKey}-MapDrawerArticle`}
       />
     </div>
   )

--- a/components/map/google/demo/index.js
+++ b/components/map/google/demo/index.js
@@ -58,28 +58,28 @@ export default () => {
         />
       </Box>
 
-      {/* <MapArticle
+      <MapArticle
         apiKey={apiKey}
         key={`${apiKey}-MapArticle`}
         height={600}
         width={600}
-      /> */}
+      />
 
-      {/* <MapImageArticle apiKey={apiKey} height={600} width={600} />
+      <MapImageArticle apiKey={apiKey} height={600} width={600} />
 
-      <MapAddOnsArticle apiKey={apiKey} key={`${apiKey}-MapAddOnsArticle`} /> */}
+      <MapAddOnsArticle apiKey={apiKey} key={`${apiKey}-MapAddOnsArticle`} />
 
-      {/* <MapCustomUIArticle
+      <MapCustomUIArticle
         apiKey={apiKey}
         key={`${apiKey}-MapCustomUIArticle`}
         height={600}
         width={600}
-      /> */}
+      />
 
       <MapDrawerArticle
         apiKey={apiKey}
-        // height={600}
-        // width={600}
+        height={600}
+        width={600}
         key={`${apiKey}-MapDrawerArticle`}
       />
     </div>

--- a/components/map/google/src/drawer/index.js
+++ b/components/map/google/src/drawer/index.js
@@ -1,0 +1,95 @@
+/* eslint-disable no-undef */
+import {useEffect} from 'react'
+
+import PropTypes from 'prop-types'
+
+import {useGoogleMap} from '@react-google-maps/api'
+
+import {
+  DISABLED_MAP_INTERACTION_OPTIONS,
+  ENABLED_MAP_INTERACTION_OPTIONS
+} from './settings.js'
+
+function GoogleMapsDrawer({
+  drawing = false,
+  onStopDrawing,
+  polylineOptions = {}
+}) {
+  const mapsLibrary = google?.maps // Looking for global google object
+  const mapRef = useGoogleMap() // Get map instance from context
+
+  useEffect(() => {
+    if (drawing) {
+      startDrawing()
+    } else {
+      stopDrawing()
+    }
+  }, [drawing]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const draw = ({polyline}) => {
+    mapsLibrary.event.addListener(mapRef, 'mousemove', event =>
+      polyline.getPath().push(event.latLng)
+    )
+  }
+
+  const clearListeners = () => {
+    mapsLibrary.event.clearListeners(mapRef, 'mousemove')
+    mapsLibrary.event.clearListeners(mapRef, 'mousedown')
+    mapsLibrary.event.clearListeners(mapRef, 'mouseup')
+  }
+
+  // This will convert the path from MVCArray<LatLng> to a LatLngLiteral array
+  const convertMVCArrayToLatLngLiteralArray = ({polyline}) => {
+    const path = polyline.getPath().getArray()
+
+    return path.map(({lat, lng}) => ({
+      lat: lat(),
+      lng: lng()
+    }))
+  }
+
+  const stopDrawing = ({polyline} = {}) => {
+    if (!mapsLibrary || !mapRef || !polyline) return []
+
+    const path = convertMVCArrayToLatLngLiteralArray({polyline})
+
+    // Remove the polyline from the map
+    polyline.setMap(null)
+
+    clearListeners()
+
+    mapRef.setOptions(ENABLED_MAP_INTERACTION_OPTIONS)
+
+    onStopDrawing({path})
+  }
+
+  const startDrawing = () => {
+    if (!mapsLibrary || !mapRef) return []
+
+    mapRef.setOptions(DISABLED_MAP_INTERACTION_OPTIONS)
+
+    const polyline = new mapsLibrary.Polyline({
+      map: mapRef,
+      clickable: false,
+      options: polylineOptions
+    })
+
+    mapsLibrary.event.addListener(mapRef, 'touchmove', e => e.preventDefault())
+    mapsLibrary.event.addListener(mapRef, 'mousedown', () => draw({polyline}))
+    mapsLibrary.event.addListener(mapRef, 'mouseup', () =>
+      stopDrawing({polyline})
+    )
+  }
+
+  // No need to render anything, just listen to drawing events and draw on the map
+  return null
+}
+
+GoogleMapsDrawer.displayName = 'GoogleMapsDrawer'
+GoogleMapsDrawer.propTypes = {
+  drawing: PropTypes.bool,
+  onStopDrawing: PropTypes.func.isRequired,
+  polylineOptions: PropTypes.object
+}
+
+export default GoogleMapsDrawer

--- a/components/map/google/src/drawer/settings.js
+++ b/components/map/google/src/drawer/settings.js
@@ -1,0 +1,13 @@
+export const DISABLED_MAP_INTERACTION_OPTIONS = {
+  disableDoubleClickZoom: false,
+  draggable: false,
+  scrollwheel: false,
+  zoomControl: false
+}
+
+export const ENABLED_MAP_INTERACTION_OPTIONS = {
+  disableDoubleClickZoom: true,
+  draggable: true,
+  scrollwheel: true,
+  zoomControl: true
+}

--- a/components/map/google/src/index.js
+++ b/components/map/google/src/index.js
@@ -8,6 +8,7 @@ import AtomSkeleton from '@s-ui/react-atom-skeleton'
 import useControlledState from '@s-ui/react-hooks/lib/useControlledState/index.js'
 
 import MapGoogleCircle from './circle/index.js'
+import MapGoogleDrawer from './drawer/index.js'
 import StaticMap from './image/index.js'
 import MapGoogleInfoWindow from './infoWindow/index.js'
 import MapGoogleMarker from './marker/index.js'
@@ -123,6 +124,7 @@ export default MapGoogle
 
 export {
   MapGoogleCircle,
+  MapGoogleDrawer,
   MapGoogleMarker,
   MapGoogleRectangle,
   StaticMap as MapGoogleImage,


### PR DESCRIPTION
## MAP/GOOGLE/DRAWER
#### 🔎  Show

### Types of changes

- [ ] 🪲 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🧾 Documentation
- [ ] 📷 Demo
- [ ] 🧪 Test
- [ ] 🧠 Refactor
- [ ] 💄 Styles

### Description, Motivation and Context

Create free hand drawer component to google maps.
It can be used as child from mapGoogle component.
You can pass a function as callback to the component, and when drawing mode is stopped  it would be called with the passing to it the path as parameter.

### Images

![Grabación-de-pantalla-2023-04-04-a-las-9 43 20](https://user-images.githubusercontent.com/17734680/229723857-118fe07a-f1f6-412c-ba7f-1af7b393d679.gif)