### PR TITLE
feat(components/tool/taskManager): Add the result param to works, so …

### DIFF
--- a/components/tool/taskManager/README.md
+++ b/components/tool/taskManager/README.md
@@ -106,7 +106,7 @@ Each of these methods allows to perform a specific interaction with the system, 
 | runTask       | Runs a complex task composed by one or more work | `{ name: string, work: Work[] }` |
 | runSimpleTask | Runs a simple task composed by just one work, and including the minimum possible amount of metadata | `{ name: string, onComplete: function, onError: function, start: function }` |
 | setPercentage | Sets the completion percentage of an specific work | `taskId: string, workId: string, percentage: number` |
-| finishWork    | Marks a work as finished, which will lead to running the next queued work or marking the task as finished if all work has been completed | `taskId: string, workId: string` |
+| finishWork    | Marks a work as finished, which will lead to running the next queued work or marking the task as finished if all work has been completed | `taskId: string, workId: string, result: any` |
 
 ## runTask
 
@@ -133,7 +133,9 @@ runTask({
           iteration++
           setPercentage(work.taskId, work.id, iteration * 10)
           if (iteration >= 10) {
-              finishWork(work.taskId, work.id)
+              finishWork(work.taskId, work.id, {
+                success: true
+              }) /* result can be left empty */
               clearInterval(interval)
           }
         },500)
@@ -165,7 +167,7 @@ runSimpleTask({
     console.log('Running work, all work data is available inside the work variable')
     setTimeout(() => {
       console.log('Simulating async progress')
-      finishWork(work.taskId, work.id)
+      finishWork(work.taskId, work.id, 'include a result message or object as third param')
       setPercentage(work.taskId, work.id, iteration * 10)
     },2000)
   }

--- a/components/tool/taskManager/src/domain/task/Entities/WorkTaskEntity.js
+++ b/components/tool/taskManager/src/domain/task/Entities/WorkTaskEntity.js
@@ -1,7 +1,6 @@
 import {Entity} from '@s-ui/domain'
 export class WorkTaskEntity extends Entity {
   constructor({
-    retryAttempts,
     config,
     createdAt,
     finishedAt,
@@ -12,13 +11,14 @@ export class WorkTaskEntity extends Entity {
     onError,
     parentId,
     percentage,
+    result,
+    retryAttempts,
     start,
     status,
     taskId,
     updatedAt
   }) {
     super({
-      retryAttempts,
       config,
       createdAt,
       finishedAt,
@@ -29,6 +29,8 @@ export class WorkTaskEntity extends Entity {
       onError,
       parentId,
       percentage,
+      result,
+      retryAttempts,
       start,
       status,
       taskId,
@@ -89,6 +91,16 @@ export class WorkTaskEntity extends Entity {
     errorCallback(this.toJSON())
   }
 
+  markAsCompleted(result) {
+    this._status.setCompleted()
+    this._percentage.set(100)
+    this._finishedAt.setNow()
+    this._result.set(result)
+
+    const callback = this._onComplete.get()
+    callback(this.toJSON())
+  }
+
   execute() {
     this._status.setInProgress()
 
@@ -98,7 +110,6 @@ export class WorkTaskEntity extends Entity {
 
   toJSON() {
     return {
-      retryAttempts: this._retryAttempts.toJSON(),
       createdAt: this._createdAt.toJSON(),
       finishedAt: this._finishedAt.toJSON(),
       id: this._id.toJSON(),
@@ -108,6 +119,8 @@ export class WorkTaskEntity extends Entity {
       onError: this._onError.toJSON(),
       parentId: this._parentId.toJSON(),
       percentage: this._percentage.toJSON(),
+      result: this._result.toJSON(),
+      retryAttempts: this._retryAttempts.toJSON(),
       start: this._start.toJSON(),
       status: this._status.toJSON(),
       taskId: this._taskId.toJSON(),

--- a/components/tool/taskManager/src/domain/task/Entities/factory.js
+++ b/components/tool/taskManager/src/domain/task/Entities/factory.js
@@ -35,7 +35,6 @@ export class TaskEntitiesFactory {
 
   static workTaskEntity = ({
     config,
-    retryAttempts,
     createdAt,
     finishedAt = null,
     id,
@@ -45,14 +44,14 @@ export class TaskEntitiesFactory {
     onError,
     parentId = null,
     percentage,
+    result = null,
+    retryAttempts,
     start,
     status,
     taskId = null,
     updatedAt = null
   }) =>
     new WorkTaskEntity({
-      retryAttempts:
-        SharedValueObjectsFactory.numberSharedValueObject(retryAttempts),
       config,
       createdAt: SharedValueObjectsFactory.dateSharedValueObject(createdAt),
       finishedAt: SharedValueObjectsFactory.dateSharedValueObject(finishedAt),
@@ -64,6 +63,9 @@ export class TaskEntitiesFactory {
       onError: SharedValueObjectsFactory.callbackSharedValueObject(onError),
       parentId: SharedValueObjectsFactory.idSharedValueObject(parentId),
       percentage: SharedValueObjectsFactory.numberSharedValueObject(percentage),
+      result: TaskValueObjectsFactory.workResultTaskValueObject(result),
+      retryAttempts:
+        SharedValueObjectsFactory.numberSharedValueObject(retryAttempts),
       start: SharedValueObjectsFactory.callbackSharedValueObject(start),
       status: TaskValueObjectsFactory.statusTaskValueObject(config, status),
       taskId: SharedValueObjectsFactory.idSharedValueObject(taskId),

--- a/components/tool/taskManager/src/domain/task/Services/FinishWorkTaskService.js
+++ b/components/tool/taskManager/src/domain/task/Services/FinishWorkTaskService.js
@@ -7,13 +7,9 @@ export class FinishWorkTaskService extends Service {
     this._taskRepository = taskRepository
   }
 
-  execute({taskId, workId} = {}) {
+  execute({taskId, workId, result} = {}) {
     const work = this._taskRepository.getWork(taskId, workId)
-    work._status.setCompleted()
-    work._percentage.set(100)
-    work._finishedAt.setNow()
-    const callback = work._onComplete.get()
-    callback(work.toJSON())
+    work.markAsCompleted(result)
     return this._taskRepository.updateWork(work)
   }
 }

--- a/components/tool/taskManager/src/domain/task/UseCases/FinishWorkTaskUseCase.js
+++ b/components/tool/taskManager/src/domain/task/UseCases/FinishWorkTaskUseCase.js
@@ -7,14 +7,15 @@ export class FinishWorkTaskUseCase extends UseCase {
     this._finishWorkTaskServiceFactory = finishWorkTaskServiceFactory
   }
 
-  execute({localState, workId, taskId} = {}) {
-    const result = this._finishWorkTaskServiceFactory({
+  execute({localState, workId, taskId, result} = {}) {
+    const finishResult = this._finishWorkTaskServiceFactory({
       config: this._config,
       localState
     }).execute({
       taskId,
-      workId
+      workId,
+      result
     })
-    return result
+    return finishResult
   }
 }

--- a/components/tool/taskManager/src/domain/task/ValueObjects/WorkResultTaskValueObject.js
+++ b/components/tool/taskManager/src/domain/task/ValueObjects/WorkResultTaskValueObject.js
@@ -1,0 +1,15 @@
+import {ValueObject} from '@s-ui/domain'
+
+export class WorkResultTaskValueObject extends ValueObject {
+  get() {
+    return this._result
+  }
+
+  set(result) {
+    this._result = result
+  }
+
+  toJSON() {
+    return this.get()
+  }
+}

--- a/components/tool/taskManager/src/domain/task/ValueObjects/factory.js
+++ b/components/tool/taskManager/src/domain/task/ValueObjects/factory.js
@@ -1,6 +1,7 @@
 import {TaskEntitiesFactory} from '../Entities/factory.js'
 import {StatusTaskValueObject} from './StatusTaskValueObject.js'
 import {WorkListTaskValueObject} from './WorkListTaskValueObject.js'
+import {WorkResultTaskValueObject} from './WorkResultTaskValueObject.js'
 
 export class TaskValueObjectsFactory {
   static statusTaskValueObject = (
@@ -23,4 +24,7 @@ export class TaskValueObjectsFactory {
     )
     return new WorkListTaskValueObject({work: workEntities})
   }
+
+  static workResultTaskValueObject = result =>
+    new WorkResultTaskValueObject({result})
 }

--- a/components/tool/taskManager/src/domain/test/task/FinishWorkTaskUseCaseSpec.js
+++ b/components/tool/taskManager/src/domain/test/task/FinishWorkTaskUseCaseSpec.js
@@ -63,4 +63,32 @@ describe('[Domain] FinishWorkTaskUseCase', () => {
     expect(work.onComplete).to.have.callCount(1)
     expect(work.onComplete).to.have.been.calledWith(work)
   })
+
+  it('should be able to receive a result object and store it inside the work', async () => {
+    // Given
+    const localState = await runSimpleTaskUseCase.execute({
+      localState: {
+        tasks: []
+      },
+      name: 'Simple task with one work',
+      start: () => null
+    })
+
+    // When
+    const stateResult = await finishWorkTaskUseCase.execute({
+      localState,
+      workId: localState.tasks[0].work[0].id,
+      taskId: localState.tasks[0].id,
+      result: {
+        fakeResultId: '123456'
+      }
+    })
+
+    // Then
+    const task = stateResult.tasks[0]
+    const work = task.work[0]
+    expect(work.result).to.deep.eql({
+      fakeResultId: '123456'
+    })
+  })
 })

--- a/components/tool/taskManager/src/hooks/useState.js
+++ b/components/tool/taskManager/src/hooks/useState.js
@@ -71,11 +71,12 @@ const useState = () => {
       percentage
     })
 
-  const finishWork = (taskId, workId) =>
+  const finishWork = (taskId, workId, result = null) =>
     executeUseCase('finish_work_task_use_case', {
       localState: stateRef.current,
       taskId,
-      workId
+      workId,
+      result
     })
 
   const cancelWork = (taskId, workId) =>


### PR DESCRIPTION
When executing a work, sometimes it's needed to store its result.

i.e. when inserting a new vehicle, the resulting vehicle id is needed later to insert its photos.

This PR introduces a new result field in work entities, in a similar way it has a `log` field for logging errors.