### PR TITLE
feat(components/tool/taskManager): Expose state reference and add method to get a specific task

### DIFF
--- a/components/tool/taskManager/src/hooks/useState.js
+++ b/components/tool/taskManager/src/hooks/useState.js
@@ -40,6 +40,8 @@ const useState = () => {
   })
   const stateRef = useRef(state)
   stateRef.current = state
+
+  const getState = () => stateRef.current
   const setState = state => dispatch({type: ACTIONS.SET_STATE, payload: state})
   const toggleTab = () => dispatch({type: ACTIONS.TOOGLE_TAB})
 
@@ -50,6 +52,8 @@ const useState = () => {
       .then(result => setState(result))
 
   useDomainEventSubscriptions(domain, executeUseCase)
+
+  const getTask = taskId => getState().tasks.find(task => task.id === taskId)
 
   const runSimpleTask = task =>
     executeUseCase('run_simple_task_use_case', {
@@ -95,13 +99,14 @@ const useState = () => {
     })
 
   return {
-    state,
     cancelWork,
     errorWork,
-    runTask,
-    runSimpleTask,
-    setPercentage,
     finishWork,
+    getState,
+    getTask,
+    runSimpleTask,
+    runTask,
+    setPercentage,
     toggleTab
   }
 }

--- a/components/tool/taskManager/src/index.js
+++ b/components/tool/taskManager/src/index.js
@@ -21,7 +21,8 @@ import useContext from './hooks/useContext.js'
 
 export default function ToolTaskManager({isVisible = true}) {
   window.taskManager = useContext()
-  const {state, toggleTab} = window.taskManager
+  const {getState, toggleTab} = window.taskManager
+  const state = getState()
   const drawerRef = useRef()
   const _onClick = () => {
     toggleTab()


### PR DESCRIPTION
Instead of returning a specific state object, which represents the state in some specific moment, expose a function which returns the latest state reference.