### PR TITLE
feat(components/tool/taskManager): Display an alert if there are in progress tasks and the window is

### DIFF
--- a/components/tool/taskManager/src/hooks/useBeforeUnloadEffect.js
+++ b/components/tool/taskManager/src/hooks/useBeforeUnloadEffect.js
@@ -1,0 +1,39 @@
+import {useCallback, useEffect} from 'react'
+
+import useContext from './useContext.js'
+
+const displayCloseAlert = e => {
+  e.preventDefault()
+  e.returnValue = ''
+}
+
+const useBeforeUnloadEffect = ({isVisible}) => {
+  const {domain, getState} = useContext()
+  const state = getState()
+  const config = domain.get('config')
+
+  const _displayCloseAlert = useCallback(
+    e => {
+      const hasInProgressTasks =
+        state.tasks.filter(
+          task => task.status === config.get('AVAILABLE_STATUS').IN_PROGRESS
+        ).length > 0
+
+      if (hasInProgressTasks) {
+        displayCloseAlert(e)
+      }
+    },
+    [config, state]
+  )
+
+  useEffect(() => {
+    if (isVisible === false) return
+
+    window.addEventListener('beforeunload', _displayCloseAlert)
+    return () => {
+      window.removeEventListener('beforeunload', _displayCloseAlert)
+    }
+  }, [_displayCloseAlert, isVisible])
+}
+
+export default useBeforeUnloadEffect

--- a/components/tool/taskManager/src/hooks/useState.js
+++ b/components/tool/taskManager/src/hooks/useState.js
@@ -100,6 +100,7 @@ const useState = () => {
 
   return {
     cancelWork,
+    domain,
     errorWork,
     finishWork,
     getState,

--- a/components/tool/taskManager/src/index.js
+++ b/components/tool/taskManager/src/index.js
@@ -17,6 +17,7 @@ import MoleculeDrawer, {
 } from '@s-ui/react-molecule-drawer'
 
 import {TaskManagerProvider} from './components/TaskManagerContext.js'
+import useBeforeUnloadEffect from './hooks/useBeforeUnloadEffect.js'
 import useContext from './hooks/useContext.js'
 
 export default function ToolTaskManager({isVisible = true}) {
@@ -24,6 +25,9 @@ export default function ToolTaskManager({isVisible = true}) {
   const {getState, toggleTab} = window.taskManager
   const state = getState()
   const drawerRef = useRef()
+
+  useBeforeUnloadEffect({isVisible})
+
   const _onClick = () => {
     toggleTab()
   }


### PR DESCRIPTION
# Changes

When closing the browser window, if there are tasks still in progress, and the task manager has been configured to be visible to the user, a confirmation popup will be displayed asking for confirmation.