### PR TITLE
feat(components/tool/taskManager): Add a feature to mark work as visible or hide it on the UI

### DIFF
--- a/components/tool/taskManager/src/domain/shared/ValueObjects/IdSharedValueObject.js
+++ b/components/tool/taskManager/src/domain/shared/ValueObjects/IdSharedValueObject.js
@@ -1,6 +1,10 @@
 import {ValueObject} from '@s-ui/domain'
 
 export class IdSharedValueObject extends ValueObject {
+  isEmpty() {
+    return this._id === null
+  }
+
   get() {
     return this._id
   }

--- a/components/tool/taskManager/src/domain/task/Entities/TaskEntity.js
+++ b/components/tool/taskManager/src/domain/task/Entities/TaskEntity.js
@@ -58,6 +58,7 @@ export class TaskEntity extends Entity {
       name: this._name.toJSON(),
       status: this._status.toJSON(),
       updatedAt: this._updatedAt.toJSON(),
+      visibleWork: this._work.countVisibleWork(),
       work: this._work.toJSON()
     }
   }

--- a/components/tool/taskManager/src/domain/task/Entities/WorkTaskEntity.js
+++ b/components/tool/taskManager/src/domain/task/Entities/WorkTaskEntity.js
@@ -5,6 +5,7 @@ export class WorkTaskEntity extends Entity {
     createdAt,
     finishedAt,
     id,
+    isVisible,
     log,
     name,
     onComplete,
@@ -23,6 +24,7 @@ export class WorkTaskEntity extends Entity {
       createdAt,
       finishedAt,
       id,
+      isVisible,
       log,
       name,
       onComplete,
@@ -64,8 +66,12 @@ export class WorkTaskEntity extends Entity {
     return false
   }
 
+  isVisible() {
+    return this._isVisible
+  }
+
   areDependenciesMet(siblingWorkList) {
-    if (this._parentId.get() === null) return true
+    if (this._parentId.isEmpty()) return true
 
     const parent = siblingWorkList.getById(this._parentId)
 
@@ -113,6 +119,7 @@ export class WorkTaskEntity extends Entity {
       createdAt: this._createdAt.toJSON(),
       finishedAt: this._finishedAt.toJSON(),
       id: this._id.toJSON(),
+      isVisible: this._isVisible,
       log: this._log.toJSON(),
       name: this._name.toJSON(),
       onComplete: this._onComplete.toJSON(),

--- a/components/tool/taskManager/src/domain/task/Entities/factory.js
+++ b/components/tool/taskManager/src/domain/task/Entities/factory.js
@@ -38,6 +38,7 @@ export class TaskEntitiesFactory {
     createdAt,
     finishedAt = null,
     id,
+    isVisible = false,
     log,
     name,
     onComplete,
@@ -56,6 +57,7 @@ export class TaskEntitiesFactory {
       createdAt: SharedValueObjectsFactory.dateSharedValueObject(createdAt),
       finishedAt: SharedValueObjectsFactory.dateSharedValueObject(finishedAt),
       id: SharedValueObjectsFactory.idSharedValueObject(id),
+      isVisible,
       log: SharedValueObjectsFactory.stringSharedValueObject(log),
       name: SharedValueObjectsFactory.stringSharedValueObject(name),
       onComplete:

--- a/components/tool/taskManager/src/domain/task/Services/RunSimpleTaskService.js
+++ b/components/tool/taskManager/src/domain/task/Services/RunSimpleTaskService.js
@@ -9,9 +9,10 @@ export class RunSimpleTaskService extends Service {
     this._taskRepository = taskRepository
   }
 
-  execute({name, onComplete, onError, start} = {}) {
+  execute({isVisible, name, onComplete, onError, start} = {}) {
     const work = {
       config: this._config,
+      isVisible,
       name,
       onComplete,
       onError,

--- a/components/tool/taskManager/src/domain/task/UseCases/RunSimpleTaskUseCase.js
+++ b/components/tool/taskManager/src/domain/task/UseCases/RunSimpleTaskUseCase.js
@@ -6,11 +6,12 @@ export class RunSimpleTaskUseCase extends UseCase {
     this._runSimpleTaskServiceFactory = runSimpleTaskServiceFactory
   }
 
-  execute({localState, name, onComplete, onError, start} = {}) {
+  execute({localState, isVisible, name, onComplete, onError, start} = {}) {
     const result = this._runSimpleTaskServiceFactory({
       config: this._config,
       localState
     }).execute({
+      isVisible,
       name,
       onComplete,
       onError,

--- a/components/tool/taskManager/src/domain/task/ValueObjects/WorkListTaskValueObject.js
+++ b/components/tool/taskManager/src/domain/task/ValueObjects/WorkListTaskValueObject.js
@@ -17,6 +17,10 @@ export class WorkListTaskValueObject extends ValueObject {
     this._work.push(work)
   }
 
+  countVisibleWork() {
+    return this._work.filter(work => work.isVisible()).length
+  }
+
   hasInProgressWork() {
     return this._work.some(work => work.isInProgress())
   }

--- a/components/tool/taskManager/src/domain/test/task/RunSimpleTaskUseCaseSpec.js
+++ b/components/tool/taskManager/src/domain/test/task/RunSimpleTaskUseCaseSpec.js
@@ -30,6 +30,7 @@ describe('[Domain] RunSimpleTaskUseCase', () => {
     expect(task.id).to.be.a('string')
     expect(task.createdAt).to.be.an.instanceOf(Date)
     expect(task.name).to.eql('Test task')
+    expect(task.visibleWork).to.eql(0)
 
     expect(task).to.have.property('work')
     expect(task.work).to.have.length(1)
@@ -41,5 +42,28 @@ describe('[Domain] RunSimpleTaskUseCase', () => {
     expect(work.id).to.be.a('string')
     expect(work.taskId).to.eql(task.id)
     expect(work.status).to.eql(config.get('AVAILABLE_STATUS').QUEUED)
+    expect(work.isVisible).to.eql(false)
+  })
+
+  it('should successfully add a new task with a visible work', async () => {
+    // Given
+    const localState = {
+      tasks: []
+    }
+
+    // When
+    const nextState = await useCase.execute({
+      localState,
+      isVisible: true,
+      name: 'Test task',
+      start: () => null
+    })
+
+    // Then
+    const task = nextState.tasks[0]
+    expect(task.visibleWork).to.eql(1)
+
+    const work = task.work[0]
+    expect(work.isVisible).to.eql(true)
   })
 })

--- a/components/tool/taskManager/src/domain/test/task/RunTaskUseCaseSpec.js
+++ b/components/tool/taskManager/src/domain/test/task/RunTaskUseCaseSpec.js
@@ -62,4 +62,101 @@ describe('[Domain] RunTaskUseCase', () => {
     assertWork(task.work[0])
     assertWork(task.work[1])
   })
+
+  it('should mark as not visible all works by default when the "isVisible" param is not specified', async () => {
+    // Given
+    const localState = {
+      tasks: []
+    }
+
+    // When
+    const nextState = await useCase.execute({
+      localState,
+      name: 'Test task',
+      work: [
+        {
+          name: 'First work',
+          onComplete: () => null,
+          onError: () => null,
+          start: () => null
+        }
+      ]
+    })
+
+    // Then
+    const firstWork = nextState.tasks[0].work[0]
+    expect(firstWork.isVisible).to.eql(false)
+  })
+
+  it('should mark as visible a work when the "isVisible" param is set as true', async () => {
+    // Given
+    const localState = {
+      tasks: []
+    }
+
+    // When
+    const nextState = await useCase.execute({
+      localState,
+      name: 'Test task',
+      work: [
+        {
+          name: 'First work',
+          onComplete: () => null,
+          onError: () => null,
+          start: () => null,
+          isVisible: true
+        }
+      ]
+    })
+
+    // Then
+    const firstWork = nextState.tasks[0].work[0]
+    expect(firstWork.isVisible).to.eql(true)
+  })
+
+  it('should include a prop to know how many works from a task are visible', async () => {
+    // Given
+    const localState = {
+      tasks: []
+    }
+
+    // When
+    const nextState = await useCase.execute({
+      localState,
+      name: 'Test task',
+      work: [
+        {
+          name: 'Work 1',
+          onComplete: () => null,
+          onError: () => null,
+          start: () => null,
+          isVisible: true
+        },
+        {
+          name: 'Work 2',
+          onComplete: () => null,
+          onError: () => null,
+          start: () => null,
+          isVisible: true
+        },
+        {
+          name: 'Work 3',
+          onComplete: () => null,
+          onError: () => null,
+          start: () => null,
+          isVisible: false
+        },
+        {
+          name: 'Work 4',
+          onComplete: () => null,
+          onError: () => null,
+          start: () => null,
+          isVisible: false
+        }
+      ]
+    })
+
+    // Then
+    expect(nextState.tasks[0].visibleWork).to.eql(2)
+  })
 })

--- a/components/tool/taskManager/src/hooks/useDevMode.js
+++ b/components/tool/taskManager/src/hooks/useDevMode.js
@@ -1,0 +1,41 @@
+import {useRef, useState} from 'react'
+
+const useDevMode = () => {
+  const clickingRef = useRef({
+    clicks: 0,
+    lastClickTime: 0
+  })
+
+  const [state, setState] = useState({
+    isDevModeEnabled: false
+  })
+
+  const registerClick = () => {
+    // If dev mode is already enabled, just skip
+    if (state.isDevModeEnabled) return
+
+    // First, if the lastClickTime was more than 500 msecs ago, we reset the clicks
+    if (clickingRef.current.lastClickTime + 250 < Date.now()) {
+      clickingRef.current = {clicks: 0, lastClickTime: Date.now()}
+      return
+    }
+
+    // Second, if the lastClickTime was less than 500 msecs ago, we increment the clicks
+    clickingRef.current = {
+      clicks: clickingRef.current.clicks + 1,
+      lastClickTime: Date.now()
+    }
+
+    // Third, if we just reached 20 clicks, display an alert
+    if (clickingRef.current.clicks >= 20) {
+      setState({isDevModeEnabled: true})
+      /* eslint-disable no-console */
+      console.log('💻 TaskManager has entered in Developer mode 💻')
+      console.log('All work will be visible and displayed from now on')
+      console.log('🧘🏽‍♀️ We wish you a peaceful debugging session 🧘🏽‍♀️')
+    }
+  }
+  return {isDevModeEnabled: state.isDevModeEnabled, registerClick}
+}
+
+export default useDevMode


### PR DESCRIPTION
# Visible work

This PR modifies the TaskManager tool, and adds the `isVisible` property to task works. `isVisible` is set to `false` by default.

When the `isVisible` prop is set to false, the work is not displayed on the UI. Additionally, if all work from a task is defined as not visible, the task itself is also not visible.

This feature will be used on CNET PRO, to control which kind of tasks can be viewed by the end user (only the video-related tasks will be visible from the begining).

We have also introduced a developer mode on the task manager, that is enabled when the user clicks consecutively 20 times on the component. When the dev mode is enabled, all tasks and works are visible, regardless of their `isVisible` prop value.