### PR TITLE
Fix: Clean listeners GoogleMapsDrawer

### DIFF
--- a/components/map/google/src/drawer/index.js
+++ b/components/map/google/src/drawer/index.js
@@ -24,6 +24,7 @@ function GoogleMapsDrawer({
     } else {
       stopDrawing()
     }
+    return () => clearListeners()
   }, [drawing]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const draw = ({polyline}) => {
@@ -33,9 +34,10 @@ function GoogleMapsDrawer({
   }
 
   const clearListeners = () => {
-    mapsLibrary.event.clearListeners(mapRef, 'mousemove')
     mapsLibrary.event.clearListeners(mapRef, 'mousedown')
+    mapsLibrary.event.clearListeners(mapRef, 'mousemove')
     mapsLibrary.event.clearListeners(mapRef, 'mouseup')
+    mapsLibrary.event.clearListeners(mapRef, 'touchmove')
   }
 
   // This will convert the path from MVCArray<LatLng> to a LatLngLiteral array
@@ -55,8 +57,6 @@ function GoogleMapsDrawer({
 
     // Remove the polyline from the map
     polyline.setMap(null)
-
-    clearListeners()
 
     mapRef.setOptions(ENABLED_MAP_INTERACTION_OPTIONS)
 

--- a/components/map/google/src/drawer/settings.js
+++ b/components/map/google/src/drawer/settings.js
@@ -1,13 +1,11 @@
 export const DISABLED_MAP_INTERACTION_OPTIONS = {
   disableDoubleClickZoom: false,
   draggable: false,
-  scrollwheel: false,
-  zoomControl: false
+  scrollwheel: false
 }
 
 export const ENABLED_MAP_INTERACTION_OPTIONS = {
   disableDoubleClickZoom: true,
   draggable: true,
-  scrollwheel: true,
-  zoomControl: true
+  scrollwheel: true
 }


### PR DESCRIPTION
Fix:
- Delete zoomControl from MAP_ITERATION_OPTIONS
- Clear all listeners in each useEffect execution to prevent draw in map when users cancel this action