### PR TITLE
feat(components/tool/taskManager): Add canBeInterrupted prop to work …

### DIFF
--- a/components/tool/taskManager/README.md
+++ b/components/tool/taskManager/README.md
@@ -118,7 +118,9 @@ runTask({
   name: 'Complex task test',
   work: [
     {
+      canBeInterrupted: false, // If true, an alert will be displayed if the user tries to close the browser while the work is still pending or in progress
       id: 'This should be unique in the whole task. Leave it undefined to autogenerate',
+      isVisible: true, // If false work won't be visible on the ui. However, it will be processed as expected, but without noticing the user
       parentId: 'The work id that must be completed before this can be executed. Leave it undefined to have no-dependencies.',
       retryAttempts: 3, // Will try the start method three times before calling the onError function
       name: 'Complex task first work',

--- a/components/tool/taskManager/src/domain/task/Entities/WorkTaskEntity.js
+++ b/components/tool/taskManager/src/domain/task/Entities/WorkTaskEntity.js
@@ -1,6 +1,7 @@
 import {Entity} from '@s-ui/domain'
 export class WorkTaskEntity extends Entity {
   constructor({
+    canBeInterrupted,
     config,
     createdAt,
     finishedAt,
@@ -20,6 +21,7 @@ export class WorkTaskEntity extends Entity {
     updatedAt
   }) {
     super({
+      canBeInterrupted,
       config,
       createdAt,
       finishedAt,
@@ -116,6 +118,7 @@ export class WorkTaskEntity extends Entity {
 
   toJSON() {
     return {
+      canBeInterrupted: this._canBeInterrupted,
       createdAt: this._createdAt.toJSON(),
       finishedAt: this._finishedAt.toJSON(),
       id: this._id.toJSON(),

--- a/components/tool/taskManager/src/domain/task/Entities/factory.js
+++ b/components/tool/taskManager/src/domain/task/Entities/factory.js
@@ -34,6 +34,7 @@ export class TaskEntitiesFactory {
   }
 
   static workTaskEntity = ({
+    canBeInterrupted = false,
     config,
     createdAt,
     finishedAt = null,
@@ -53,6 +54,7 @@ export class TaskEntitiesFactory {
     updatedAt = null
   }) =>
     new WorkTaskEntity({
+      canBeInterrupted,
       config,
       createdAt: SharedValueObjectsFactory.dateSharedValueObject(createdAt),
       finishedAt: SharedValueObjectsFactory.dateSharedValueObject(finishedAt),

--- a/components/tool/taskManager/src/hooks/useBeforeUnloadEffect.js
+++ b/components/tool/taskManager/src/hooks/useBeforeUnloadEffect.js
@@ -14,9 +14,17 @@ const useBeforeUnloadEffect = ({isVisible}) => {
 
   const _displayCloseAlert = useCallback(
     e => {
+      // Si la task está in progress y además tiene algún work donde displayOnCloseAlert sea true
+      // y no esté finalizado
       const hasInProgressTasks =
         state.tasks.filter(
-          task => task.status === config.get('AVAILABLE_STATUS').IN_PROGRESS
+          task =>
+            task.status === config.get('AVAILABLE_STATUS').IN_PROGRESS &&
+            task.work.filter(
+              work =>
+                work.canBeInterrupted === false &&
+                work.status !== config.get('AVAILABLE_STATUS').COMPLETED
+            ).length > 0
         ).length > 0
 
       if (hasInProgressTasks) {


### PR DESCRIPTION
# Description

Add a parameter to indicate wether a work can be interrupted or not without suffering data loss or compromising the task execution integrity. By default, it will be `false` for all works.

Currently TaskManager was displaying a confirmation alert when user tried to close the browser and there were unfinished works. Now, it will only closed this alert if there is one or more pending works with `canBeInterrupted` props set to `false`. This means that if all works are registered as interruptable, or all pending works are marked as `canBeInterrupted` the user will not need to confirm the action of closing the browser or the tab.

We are implementing this because there are some works that are currently executed on the backend, and closing the browser doesn't actually interrupt the work execution, so there is no need to alert the user and confirm the action of closing the browser. However, we'll keep `canBeInterrupted` set to `false` for all other works that are executed on the browser (submitting a form, uploading images, videos, etcetera).