### PR TITLE
feat(components/perf/dynamicRendering): add content-visibility property

### DIFF
--- a/components/perf/dynamicRendering/src/index.js
+++ b/components/perf/dynamicRendering/src/index.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types'
 
+import LazyContent from './lazyContent.js'
+
 import './index.scss'
-import LazyContent from './lazyContent'
 
 const BOTS_USER_AGENTS = [
   'googlebot',
@@ -41,11 +42,7 @@ export default function PerfDynamicRendering({
   // so check if we're on the browser side and if is not disabled the component
   if (isOnBrowser && !disabled) {
     return (
-      <LazyContent
-        rootMargin={rootMargin}
-        placeholder={placeholder}
-        height={height}
-      >
+      <LazyContent rootMargin={rootMargin} placeholder={placeholder} height={height}>
         {children}
       </LazyContent>
     )
@@ -53,7 +50,7 @@ export default function PerfDynamicRendering({
     // so, we're on the server side or the component is disabled
     return placeholder
   } else {
-    return <div style={{containIntrinsicSize: auto `${height}px`, height: `${height}px`, marginBottom: '1px'}} />
+    return <div style={{containIntrinsicSize: `auto ${height}px`, height: `${height}px`, marginBottom: '1px'}} />
   }
 }
 

--- a/components/perf/dynamicRendering/src/index.js
+++ b/components/perf/dynamicRendering/src/index.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 
+import './index.scss'
 import LazyContent from './lazyContent'
 
 const BOTS_USER_AGENTS = [
@@ -52,7 +53,7 @@ export default function PerfDynamicRendering({
     // so, we're on the server side or the component is disabled
     return placeholder
   } else {
-    return <div style={{height: `${height}px`, marginBottom: '1px'}} />
+    return <div style={{containIntrinsicSize: auto `${height}px`, height: `${height}px`, marginBottom: '1px'}} />
   }
 }
 

--- a/components/perf/dynamicRendering/src/index.scss
+++ b/components/perf/dynamicRendering/src/index.scss
@@ -1,1 +1,3 @@
-// EMPTY. Keep to get studio working as expected
+.sui-PerfDynamicRendering-placeholder {
+  content-visibility: auto;
+}


### PR DESCRIPTION
## What?

Add the CSS property `content-visibility` to improve the performance.

## Why?

We want to reduce the rendering time to improve the INP.

## Reference

[content-visibility: the new CSS property that boosts your rendering performance](https://web.dev/articles/content-visibility)

#### _Effects on Interaction to Next Paint (INP)_

_[INP](https://web.dev/articles/inp) is a metric that evaluates a page's ability to be reliably responsive to user input. Responsiveness can be affected by any excessive amount of work that occurs on the main thread, including rendering work._

_Whenever you can reduce rendering work on any given page, you're giving the main thread an opportunity to respond to user inputs more quickly. This includes rendering work, and using the content-visiblity CSS property where appropriate can reduce rendering work—especially during startup, when most rendering and layout work is done._

_Reducing rendering work has a direct effect on INP. When users attempt to interact with a page that uses the content-visibility property properly to defer layout and rendering of offscreen elements, you're giving the main thread a chance to respond to critical user-visible work. This can improve your page's INP in some situations._