### PR TITLE
fix(components/perf/dynamicRendering): hydration mismatch

### DIFF
--- a/components/perf/dynamicRendering/src/index.js
+++ b/components/perf/dynamicRendering/src/index.js
@@ -33,7 +33,6 @@ export default function PerfDynamicRendering({
 }) {
   const isBot = checkUserAgentIsBot(userAgent, botsUserAgents)
   const [isOnBrowser, setIsOnBrowser] = useState(false)
-  // const isOnBrowser = typeof window !== 'undefined'
 
   useEffect(() => {
     setIsOnBrowser(true)

--- a/components/perf/dynamicRendering/src/index.js
+++ b/components/perf/dynamicRendering/src/index.js
@@ -1,3 +1,5 @@
+import {useEffect, useState} from 'react'
+
 import PropTypes from 'prop-types'
 
 import LazyContent from './lazyContent.js'
@@ -30,7 +32,12 @@ export default function PerfDynamicRendering({
   userAgent
 }) {
   const isBot = checkUserAgentIsBot(userAgent, botsUserAgents)
-  const isOnBrowser = typeof window !== 'undefined'
+  const [isOnBrowser, setIsOnBrowser] = useState(false)
+  // const isOnBrowser = typeof window !== 'undefined'
+
+  useEffect(() => {
+    setIsOnBrowser(true)
+  }, [])
 
   // Force render in server and client
   if (forceRender) return children


### PR DESCRIPTION
This PR fixes a hydration mismatch issue caused by `const isOnBrowser = typeof window !== 'undefined'` side-effect in render