### PR TITLE
fix(components/perf/dynamicRendering): remove content-visibility rule to avoid CLS problem

### DIFF
--- a/components/perf/dynamicRendering/src/index.scss
+++ b/components/perf/dynamicRendering/src/index.scss
@@ -1,4 +1,3 @@
 .sui-PerfDynamicRendering-placeholder {
-  content-visibility: auto;
   width: 100%;
 }


### PR DESCRIPTION
JIRA: https://jira.ets.mpi-internal.com/browse/SCMI-115243

Content visibility auto seems to do not reserve the height space in items that are above the current scroll position. So when we do a scroll up this items spam in height and that triggers CLS.

https://github.com/SUI-Components/adevinta-spain-components/assets/66824007/69be21c9-0685-4908-bc2a-c34ae2562474

