### PR TITLE
feat(components/tool/app): Add isNative method

### DIFF
--- a/components/tool/app/bin/commands/addBiometricConfig.js
+++ b/components/tool/app/bin/commands/addBiometricConfig.js
@@ -47,7 +47,7 @@ const addAndroidBiometricConfig = async () => {
   })
 
   // Add uses-feature
-  manifest.manifest.application[0]['uses-feature'] = {
+  manifest.manifest['uses-feature'] = {
     $: {
       'android:name': 'android.hardware.fingerprint',
       'android:required': 'false'

--- a/components/tool/app/src/core.js
+++ b/components/tool/app/src/core.js
@@ -1,0 +1,3 @@
+import {Capacitor} from '@capacitor/core'
+
+export const isNative = () => Capacitor.isNativePlatform()

--- a/components/tool/app/src/index.js
+++ b/components/tool/app/src/index.js
@@ -1,8 +1,9 @@
 import * as biometric from './biometric.js'
+import * as core from './core.js'
 import * as localNotifications from './localNotifications.js'
 
 export default function SuiApp() {
   throw new Error('sui-app is a set of tools and is not intended to be renderized as a React component')
 }
 
-export {biometric, localNotifications}
+export {biometric, core, localNotifications}


### PR DESCRIPTION
This PR adds a new wrapped method from the Capacitor's API, to know if an app is currently running on a native platform, and differentiate from normal web browsers.

It also fixes a bug when defining biometric permissions on android.