### PR TITLE
feat(components/tool/app): Always install capacitor 5 related plugins

### DIFF
--- a/components/tool/app/bin/commands/addLiveUpdate.js
+++ b/components/tool/app/bin/commands/addLiveUpdate.js
@@ -19,6 +19,6 @@ module.exports = () => {
     reportError(`\n\nThis project has not been initialized. sui-app cannot configure live updates\n\n`)
   }
 
-  if (!hasDependency('@capgo/capacitor-updater')) installDependency('@capgo/capacitor-updater')
+  if (!hasDependency('@capgo/capacitor-updater')) installDependency('@capgo/capacitor-updater@5')
   else reportError(`\n\nLive updates were already installed\n\n`)
 }

--- a/components/tool/app/bin/commands/init.js
+++ b/components/tool/app/bin/commands/init.js
@@ -106,13 +106,13 @@ module.exports = async () => {
     installDependency(PACKAGE_NAME)
   }
 
-  if (!hasDependency('@capgo/capacitor-native-biometric')) installDependency('@capgo/capacitor-native-biometric')
+  if (!hasDependency('@capgo/capacitor-native-biometric')) installDependency('@capgo/capacitor-native-biometric@5')
 
-  if (!hasDependency('@capacitor/local-notifications')) installDependency('@capacitor/local-notifications')
+  if (!hasDependency('@capacitor/local-notifications')) installDependency('@capacitor/local-notifications@5')
 
-  if (!hasDependency('@capgo/capacitor-updater')) installDependency('@capgo/capacitor-updater')
+  if (!hasDependency('@capgo/capacitor-updater')) installDependency('@capgo/capacitor-updater@5')
 
-  if (!hasDependency('@capacitor/app')) installDependency('@capacitor/app')
+  if (!hasDependency('@capacitor/app')) installDependency('@capacitor/app@5')
 
   // If app has already been initialized
   if (hasCapacitorConfig()) {


### PR DESCRIPTION
Forcing the usage of Capacitor 5 until capgo updates all their plugins to the version 6.