### PR TITLE
Feat: Add new unfinished drawing function on google maps drawer

### DIFF
--- a/components/map/google/package.json
+++ b/components/map/google/package.json
@@ -17,8 +17,8 @@
   "dependencies": {
     "@react-google-maps/api": "2.12.1",
     "@s-ui/js": "2",
+    "@s-ui/react-atom-skeleton": "1",
     "@s-ui/react-hooks": "1",
-    "@s-ui/react-primitive-injector": "1",
-    "@s-ui/react-atom-skeleton": "1"
+    "@s-ui/react-primitive-injector": "1"
   }
 }


### PR DESCRIPTION
## DOMAIN/SEARCH/V2

<!--
DON'T FORGET TO ADD LABEL ship, show or ask on Pull Request to notify about your PR in re-frontend-prs Slack channel
-->

<!-- For example DOMAIN/ALERTS or LITERALS or PAGES/DETAIL -->

**ℹ️ TASK**: [SCMI-122666](https://jira.ets.mpi-internal.com/browse/SCMI-122666)

### ✅ Types of changes

<!-- Check only the type or types of change in this pull request: -->
- [X] New feature (non-breaking change which adds functionality)

### 📝 Description, Motivation and Context

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it is solving an issue... How can it be reproduced in order to compare between both behaviors? -->
Add new unfinishedDrawing function on google maps drawer

This function is necessary for detect when users draw on map but never finish the polygon (just do a click on the map or the polygon has less than 3 points)