### PR TITLE
feat(components/share/socialMediaButtonsGroup): Change Whatsapp share url to improve open graph meta

### DIFF
--- a/components/share/socialMediaButtonsGroup/src/config.js
+++ b/components/share/socialMediaButtonsGroup/src/config.js
@@ -9,7 +9,7 @@ const DEFAULT_SOCIAL_MEDIA_DICTIONARY = {
   whatsapp: {
     design: 'outline',
     literal: 'WhatsApp',
-    url: 'https://wa.me/?text='
+    url: 'https://api.whatsapp.com/send?text='
   },
   facebook: {
     design: 'outline',


### PR DESCRIPTION
**Problem:**
Sometimes, when we are sharing an ad through WhatsApp, seems like some links are not sharing the og:image meta tag on the message. Checking our code, we were using **https://wa.me/?text=** api and seems like is not fully compatible with open graph
![Screenshot 2024-10-30 at 12 10 38](https://github.com/user-attachments/assets/e0fe5c99-f93c-48c1-a26b-e2e0e37c3ba4)
![Screenshot 2024-10-30 at 12 13 35](https://github.com/user-attachments/assets/26ce5897-ac9a-43ac-88dd-e44d47fbccef)

**Solution:**
We could use **https://api.whatsapp.com/send?text=** api which is more compatible.

![Screenshot 2024-10-30 at 12 14 51](https://github.com/user-attachments/assets/1136327c-686f-41c8-8b5b-36a73feb0119)
![Screenshot 2024-10-30 at 12 16 54](https://github.com/user-attachments/assets/012c210c-0e1c-4872-a93d-0219acf14603)
