### PR TITLE
feat(components/form/builder): remove duplicate labels on selects and…

### DIFF
--- a/components/form/builder/src/Select/Autosuggest/index.js
+++ b/components/form/builder/src/Select/Autosuggest/index.js
@@ -134,11 +134,6 @@ const AutosuggestSelect = ({select, tabIndex, onChange, onFocus, onBlur, size, e
   // render SUI component
   return (
     <div className={`sui-FormBuilder-field sui-FormBuilder-AutosuggestSelect sui-FormBuilder-${autosuggestProps.id}`}>
-      {autosuggestProps.label && (
-        <label className="sui-FormBuilder-label" htmlFor={autosuggestProps.id}>
-          {autosuggestProps.label}
-        </label>
-      )}
       <MoleculeAutosuggestField {...autosuggestProps} {...rendererResponse}>
         {suggestions.map((suggestion, i) => (
           <MoleculeAutosuggestOption key={suggestion.value} value={suggestion.text}>

--- a/components/form/builder/src/Select/Default/index.js
+++ b/components/form/builder/src/Select/Default/index.js
@@ -114,12 +114,6 @@ const DefaultSelect = ({
     <div className={`sui-FormBuilder-field sui-FormBuilder-DefaultSelect sui-FormBuilder-${selectProps.id}`}>
       {selectProps.children}
 
-      {selectProps.label && (
-        <label className="sui-FormBuilder-label" htmlFor={selectProps.id}>
-          {selectProps.label}
-        </label>
-      )}
-
       <MoleculeSelectField {...selectProps} {...rendererResponse} multiselection={multiselection}>
         {nextDataList.map(({value, text, description, leftAddon, ...others}) => (
           <MoleculeSelectOption key={value} value={value} description={description} leftAddon={leftAddon} {...others}>

--- a/components/form/builder/src/index.scss
+++ b/components/form/builder/src/index.scss
@@ -19,22 +19,8 @@ $self: 'sui-FormBuilder';
 $bg-form-builder: transparent !default;
 $p-form-builder: 0 !default;
 $bdrs-form-builder: 0 !default;
-$fz-form-builder-label: $fz-base !default;
 $m-form-builder-field: 0 $m-m $m-l $m-m !default;
 $m-form-builder-radio-label: 0 0 $m-l 0 !default;
-
-// TODO: Remove after SUI comp allows hidden accessible labels
-@mixin visually-hidden {
-  &:not(:focus):not(:active) {
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
-}
 
 .#{$self} {
   background: $bg-form-builder;
@@ -46,13 +32,6 @@ $m-form-builder-radio-label: 0 0 $m-l 0 !default;
     width: calc(100% - #{$m-l});
   }
 
-  &-label {
-    display: block;
-    font-size: $fz-form-builder-label;
-    margin-bottom: $m-s;
-
-    @include visually-hidden();
-  }
   .#{$self}-Radio-label {
     display: inline-block;
     margin: $m-form-builder-radio-label;


### PR DESCRIPTION
Remove duplicate labels on select and auto-suggest field types, to accomplish a11y rules.
With this change, only the `MoleculeSelectField` or `MoleculeAutosuggestField` labels will be rendered.