### PR TITLE
feat(components/form/builder): let assign an id to every button of an…

### DIFF
--- a/components/form/builder/src/InlineButton/index.js
+++ b/components/form/builder/src/InlineButton/index.js
@@ -66,6 +66,7 @@ const InlineButton = ({inlineButton, tabIndex, onChange, errors, alerts, rendere
         {rendererResponse?.children ||
           datalist.map(button => (
             <Button
+              id={button.id ?? `${inlineButton.id}-${button.value}`}
               key={button.text}
               design={button.value === inlineButton.value ? 'solid' : 'outline'}
               onClick={() => onClickHandler(button.value)}


### PR DESCRIPTION
Add id assignation for every button of an inline button field type.
Currently the same ID is passed for every button, and that's not a11y compliant.
With this PR we can define a different ID on our form config, or automatically set a default one combining inlineButton id and button value.