### PR TITLE
Feature/a11y  form builder  use paragraph on help error and alert field texts

### DIFF
--- a/components/form/builder/src/Checkbox/index.js
+++ b/components/form/builder/src/Checkbox/index.js
@@ -52,10 +52,10 @@ const Checkbox = ({checkbox, tabIndex, onChange, onFocus, onBlur, errors, alerts
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 

--- a/components/form/builder/src/InlineButton/index.js
+++ b/components/form/builder/src/InlineButton/index.js
@@ -36,10 +36,10 @@ const InlineButton = ({inlineButton, tabIndex, onChange, errors, alerts, rendere
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 

--- a/components/form/builder/src/Input/index.js
+++ b/components/form/builder/src/Input/index.js
@@ -100,10 +100,10 @@ const Input = ({input, tabIndex, onChange, onFocus, onBlur, size, leftAddon, rig
       disabled: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 
@@ -113,7 +113,7 @@ const Input = ({input, tabIndex, onChange, onFocus, onBlur, size, leftAddon, rig
     label: input.label || '',
     tabIndex,
     placeholder: input.hint,
-    helpText: input.help,
+    helpText: input.help && <p>{input.help}</p>,
     value: input.value || '',
     onChange: onChangeCallback,
     onFocus: onFocusCallback,

--- a/components/form/builder/src/MultiButton/index.js
+++ b/components/form/builder/src/MultiButton/index.js
@@ -35,10 +35,10 @@ const MultiButton = ({alerts, errors, multiButton, onBlur, onChange, onFocus, re
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 

--- a/components/form/builder/src/Multicheckbox/index.js
+++ b/components/form/builder/src/Multicheckbox/index.js
@@ -46,10 +46,10 @@ const Multipicker = ({multipicker, tabIndex, onChange, onFocus, onBlur, errors, 
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 

--- a/components/form/builder/src/PickerSlider/index.js
+++ b/components/form/builder/src/PickerSlider/index.js
@@ -43,9 +43,11 @@ const PickerSlider = ({slider, onChange, onFocus, onBlur, errors, alerts, render
     return null
   }
 
-  const errorText = errorMessages && errorMessages.join('\n')
-  const alertText = alertMessages && alertMessages.join('\n')
-  const helpText = slider.help
+  const errorText =
+    errorMessages && errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+  const alertText =
+    alertMessages && alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+  const helpText = slider.help && <p>{slider.help}</p>
   const marks = [formatter(min), formatter(max)]
 
   const response = renderer({

--- a/components/form/builder/src/Radio/index.js
+++ b/components/form/builder/src/Radio/index.js
@@ -26,10 +26,10 @@ const Radio = ({radio, tabIndex, onChange, errors, alerts, renderer}) => {
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 
@@ -65,7 +65,7 @@ const Radio = ({radio, tabIndex, onChange, errors, alerts, renderer}) => {
             key={button.value}
             value={button.value}
             label={button.text}
-            helpText={button.hint}
+            helpText={button.hint && <p>{button.hint}</p>}
           />
         ))}
       </MoleculeRadioButtonGroup>

--- a/components/form/builder/src/Range/Default/index.js
+++ b/components/form/builder/src/Range/Default/index.js
@@ -63,7 +63,7 @@ const DefaultRange = ({range, tabIndex, onChange, onFocus, onBlur, errors, alert
     onChange: onChangeCallback,
     onBlur: onBlurCallback,
     onFocus: onFocusCallback,
-    helpText: range.help,
+    helpText: range.help && <p>{range.help}</p>,
     tabIndex
   }
 
@@ -75,7 +75,7 @@ const DefaultRange = ({range, tabIndex, onChange, onFocus, onBlur, errors, alert
     onChange: onChangeCallback,
     onBlur: onBlurCallback,
     onFocus: onFocusCallback,
-    helpText: range.help,
+    helpText: range.help && <p>{range.help}</p>,
     tabIndex
   }
 

--- a/components/form/builder/src/Select/Autosuggest/index.js
+++ b/components/form/builder/src/Select/Autosuggest/index.js
@@ -20,8 +20,8 @@ const fromTextToValue = datalist => text => {
 }
 
 const AutosuggestSelect = ({select, tabIndex, onChange, onFocus, onBlur, size, errors, alerts, renderer}) => {
-  const errorMessages = errors[select.id] || []
-  const alertMessages = alerts[select.id] || []
+  const errorMessages = errors[select.id]
+  const alertMessages = alerts[select.id]
 
   const {datalist = []} = select
   const fromTextToValueWithDatalist = fromTextToValue(datalist)
@@ -80,11 +80,7 @@ const AutosuggestSelect = ({select, tabIndex, onChange, onFocus, onBlur, size, e
    * - There are no other errors involved
    */
   const showEmptySuggestionText =
-    !suggestions.length && !!localStateText && select.emptySuggestionText && !errorMessages.length
-
-  if (showEmptySuggestionText) {
-    errorMessages.push(select.emptySuggestionText)
-  }
+    !suggestions.length && !!localStateText && select.emptySuggestionText && !errorMessages?.length
 
   const autosuggestProps = {
     id: select.id,
@@ -106,6 +102,9 @@ const AutosuggestSelect = ({select, tabIndex, onChange, onFocus, onBlur, size, e
     }),
     ...(!!errorMessages && {
       errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    }),
+    ...(showEmptySuggestionText && {
+      errorText: [select.emptySuggestionText]
     }),
     ...(!!alertMessages && {
       alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)

--- a/components/form/builder/src/Select/Autosuggest/index.js
+++ b/components/form/builder/src/Select/Autosuggest/index.js
@@ -92,7 +92,7 @@ const AutosuggestSelect = ({select, tabIndex, onChange, onFocus, onBlur, size, e
     name: select.name,
     placeholder: select.hint,
     onChange: onChangeCallback,
-    helpText: select.help,
+    helpText: select.help && <p>{select.help}</p>,
     onBlur: onBlurCallback,
     onFocus: onFocusCallback,
     iconClear: <IconClose />,
@@ -105,10 +105,10 @@ const AutosuggestSelect = ({select, tabIndex, onChange, onFocus, onBlur, size, e
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     }),
     selectSize: size,
     ...constraintsProps

--- a/components/form/builder/src/Select/Default/index.js
+++ b/components/form/builder/src/Select/Default/index.js
@@ -72,7 +72,7 @@ const DefaultSelect = ({
     onChange: onChangeCallback,
     onBlur: onBlurCallback,
     onFocus: onFocusCallback,
-    helpText: select.help,
+    helpText: select.help && <p>{select.help}</p>,
     tabIndex,
     ...(select.disabled && {
       disabled: true
@@ -81,10 +81,10 @@ const DefaultSelect = ({
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     }),
     selectSize: size,
     ...constraintsProps

--- a/components/form/builder/src/Stepper/index.js
+++ b/components/form/builder/src/Stepper/index.js
@@ -34,10 +34,10 @@ const Stepper = ({stepper, tabIndex, onChange, errors, alerts, renderer}) => {
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 

--- a/components/form/builder/src/Switch/index.js
+++ b/components/form/builder/src/Switch/index.js
@@ -32,10 +32,10 @@ const Switch = ({switchField, tabIndex, onChange, errors, alerts, renderer}) => 
       hidden: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 

--- a/components/form/builder/src/TextArea/index.js
+++ b/components/form/builder/src/TextArea/index.js
@@ -52,10 +52,10 @@ const TextArea = ({textArea, tabIndex, onChange, onFocus, onBlur, errors, alerts
       disabled: true
     }),
     ...(!!errorMessages && {
-      errorText: errorMessages.join('\n')
+      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
     }),
     ...(!!alertMessages && {
-      alertText: alertMessages.join('\n')
+      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
     })
   }
 


### PR DESCRIPTION
# a11y / FormBuilder

#### `🔍 Show`

### Description, Motivation and Context

This PR addresses an accessibility issue reported during an audit.

Make all helpTexts, errorTexts, and alertTexts of every field type to be a paragraph element ( `<p>` ), replacing the current span element.

### Types of changes

- [x] 🦾 a11y
- [x] ✨ New feature (non-breaking change which adds functionality)