### PR TITLE
feat(components/form/builder): errorText and alerText will be empty s…

### DIFF
--- a/components/form/builder/src/Checkbox/index.js
+++ b/components/form/builder/src/Checkbox/index.js
@@ -33,6 +33,14 @@ const Checkbox = ({checkbox, tabIndex, onChange, onFocus, onBlur, errors, alerts
     }
   }, checkboxProps)
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   checkboxProps = {
     ...checkboxProps,
     id: checkbox.id,
@@ -45,18 +53,10 @@ const Checkbox = ({checkbox, tabIndex, onChange, onFocus, onBlur, errors, alerts
     onBlur: onBlurCallback,
     tabIndex,
     intermediate: false,
-    ...(checkbox.disabled && {
-      disabled: true
-    }),
-    ...(checkbox.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(checkbox.disabled && {disabled: true}),
+    ...(checkbox.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   if (checkboxProps.hidden) {

--- a/components/form/builder/src/InlineButton/index.js
+++ b/components/form/builder/src/InlineButton/index.js
@@ -23,24 +23,24 @@ const InlineButton = ({inlineButton, tabIndex, onChange, errors, alerts, rendere
     [onChange, inlineButton]
   )
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const inlineButtonProps = {
     id: inlineButton.id,
     label: inlineButton.label,
     tabIndex,
     value: inlineButton.value || '',
     onChange: onChangeCallback,
-    ...(inlineButton.disabled && {
-      disabled: true
-    }),
-    ...(inlineButton.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(inlineButton.disabled && {disabled: true}),
+    ...(inlineButton.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   if (inlineButtonProps.hidden) {

--- a/components/form/builder/src/Input/index.js
+++ b/components/form/builder/src/Input/index.js
@@ -91,20 +91,20 @@ const Input = ({input, tabIndex, onChange, onFocus, onBlur, size, leftAddon, rig
     }
   }
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   nextProps = {
     ...nextProps,
-    ...(input.hidden && {
-      hidden: true
-    }),
-    ...(input.disabled && {
-      disabled: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(input.hidden && {hidden: true}),
+    ...(input.disabled && {disabled: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   const inputProps = {

--- a/components/form/builder/src/MultiButton/index.js
+++ b/components/form/builder/src/MultiButton/index.js
@@ -21,6 +21,14 @@ const MultiButton = ({alerts, errors, multiButton, onBlur, onChange, onFocus, re
 
   const onBlurCallback = () => onBlur(multiButton.id)
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const multiButtonProps = {
     id: multiButton.id,
     label: multiButton.label,
@@ -28,18 +36,10 @@ const MultiButton = ({alerts, errors, multiButton, onBlur, onChange, onFocus, re
     onFocus: onFocusCallback,
     tabIndex,
     value: multiButton.value,
-    ...(multiButton.disabled && {
-      disabled: true
-    }),
-    ...(multiButton.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(multiButton.disabled && {disabled: true}),
+    ...(multiButton.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   if (multiButtonProps.hidden) return null

--- a/components/form/builder/src/Multicheckbox/index.js
+++ b/components/form/builder/src/Multicheckbox/index.js
@@ -29,6 +29,14 @@ const Multipicker = ({multipicker, tabIndex, onChange, onFocus, onBlur, errors, 
 
   const onBlurCallback = () => onBlur(multipicker.id)
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const multipickerProps = {
     id: multipicker.id,
     label: multipicker.label,
@@ -39,18 +47,10 @@ const Multipicker = ({multipicker, tabIndex, onChange, onFocus, onBlur, errors, 
     onBlur: onBlurCallback,
     tabIndex,
     intermediate: false,
-    ...(multipicker.disabled && {
-      disabled: true
-    }),
-    ...(multipicker.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(multipicker.disabled && {disabled: true}),
+    ...(multipicker.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   if (multipickerProps.hidden) {

--- a/components/form/builder/src/PickerSlider/index.js
+++ b/components/form/builder/src/PickerSlider/index.js
@@ -43,10 +43,14 @@ const PickerSlider = ({slider, onChange, onFocus, onBlur, errors, alerts, render
     return null
   }
 
-  const errorText =
-    errorMessages && errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-  const alertText =
-    alertMessages && alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const helpText = slider.help && <p>{slider.help}</p>
   const marks = [formatter(min), formatter(max)]
 

--- a/components/form/builder/src/Radio/index.js
+++ b/components/form/builder/src/Radio/index.js
@@ -15,22 +15,22 @@ const Radio = ({radio, tabIndex, onChange, errors, alerts, renderer}) => {
     return onChange(radio.id, value)
   }
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const radioProps = {
     id: radio.id,
     label: radio.label,
     tabIndex,
-    ...(radio.disabled && {
-      disabled: true
-    }),
-    ...(radio.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(radio.disabled && {disabled: true}),
+    ...(radio.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   if (radioProps.hidden) {

--- a/components/form/builder/src/Select/Autosuggest/index.js
+++ b/components/form/builder/src/Select/Autosuggest/index.js
@@ -82,6 +82,14 @@ const AutosuggestSelect = ({select, tabIndex, onChange, onFocus, onBlur, size, e
   const showEmptySuggestionText =
     !suggestions.length && !!localStateText && select.emptySuggestionText && !errorMessages?.length
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const autosuggestProps = {
     id: select.id,
     label: select.label,
@@ -94,21 +102,11 @@ const AutosuggestSelect = ({select, tabIndex, onChange, onFocus, onBlur, size, e
     iconClear: <IconClose />,
     value: localStateText,
     tabIndex,
-    ...(select.disabled && {
-      disabled: true
-    }),
-    ...(select.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(showEmptySuggestionText && {
-      errorText: [select.emptySuggestionText]
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    }),
+    ...(select.disabled && {disabled: true}),
+    ...(select.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText}),
+    ...(showEmptySuggestionText && {errorText: [select.emptySuggestionText]}),
     selectSize: size,
     ...constraintsProps
   }

--- a/components/form/builder/src/Select/Default/index.js
+++ b/components/form/builder/src/Select/Default/index.js
@@ -59,6 +59,14 @@ const DefaultSelect = ({
 
   const DEFAULT_SELECT_VALUE = multiselection ? [] : ''
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const selectProps = {
     id: select.id,
     label: select.label,
@@ -74,18 +82,10 @@ const DefaultSelect = ({
     onFocus: onFocusCallback,
     helpText: select.help && <p>{select.help}</p>,
     tabIndex,
-    ...(select.disabled && {
-      disabled: true
-    }),
-    ...(select.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    }),
+    ...(select.disabled && {disabled: true}),
+    ...(select.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText}),
     selectSize: size,
     ...constraintsProps
   }

--- a/components/form/builder/src/Stepper/index.js
+++ b/components/form/builder/src/Stepper/index.js
@@ -17,6 +17,14 @@ const Stepper = ({stepper, tabIndex, onChange, errors, alerts, renderer}) => {
 
   const onChangeHandler = (__, {value}) => onChange(stepper.id, value)
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const stepperProps = {
     id: stepper.id,
     inputDisabled: stepper.inputDisabled,
@@ -27,18 +35,10 @@ const Stepper = ({stepper, tabIndex, onChange, errors, alerts, renderer}) => {
     minValueErrorText: stepper.minValueErrorText,
     tabIndex,
     value: stepper.value,
-    ...(stepper.disabled && {
-      disabled: true
-    }),
-    ...(stepper.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(stepper.disabled && {disabled: true}),
+    ...(stepper.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   if (stepperProps.hidden) {

--- a/components/form/builder/src/Switch/index.js
+++ b/components/form/builder/src/Switch/index.js
@@ -18,6 +18,15 @@ const Switch = ({switchField, tabIndex, onChange, errors, alerts, renderer}) => 
     },
     [onChange, switchField]
   )
+
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   const switchProps = {
     name: switchField.id,
     label: switchField.label,
@@ -25,18 +34,10 @@ const Switch = ({switchField, tabIndex, onChange, errors, alerts, renderer}) => 
     value: switched,
     onToggle: onChangeCallback,
     type: 'single',
-    ...(switchField.disabled && {
-      disabled: true
-    }),
-    ...(switchField.hidden && {
-      hidden: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(switchField.disabled && {disabled: true}),
+    ...(switchField.hidden && {hidden: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   if (switchProps.hidden) {

--- a/components/form/builder/src/TextArea/index.js
+++ b/components/form/builder/src/TextArea/index.js
@@ -43,20 +43,20 @@ const TextArea = ({textArea, tabIndex, onChange, onFocus, onBlur, errors, alerts
     }
   }, nextProps)
 
+  const errorText = errorMessages?.length
+    ? errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
+    : ''
+
+  const alertText = alertMessages?.length
+    ? alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
+    : ''
+
   nextProps = {
     ...nextProps,
-    ...(textArea.hidden && {
-      hidden: true
-    }),
-    ...(textArea.disabled && {
-      disabled: true
-    }),
-    ...(!!errorMessages && {
-      errorText: errorMessages.map((errorMessage, index) => <p key={`${errorMessage}-${index}`}>{errorMessage}</p>)
-    }),
-    ...(!!alertMessages && {
-      alertText: alertMessages.map((alertMessage, index) => <p key={`${alertMessage}-${index}`}>{alertMessage}</p>)
-    })
+    ...(textArea.hidden && {hidden: true}),
+    ...(textArea.disabled && {disabled: true}),
+    ...(!!errorMessages && {errorText}),
+    ...(!!alertMessages && {alertText})
   }
 
   const textAreaProps = {


### PR DESCRIPTION
## Form / Builder

With a previous PR, the empty value of `errorText` and `alertText` of every field was modified from the expected **empty string** to **empty array**. 
And it is painting fields like error fields, so I modified again to return the expected empty value ( `''` ).

![image](https://github.com/user-attachments/assets/8502aefe-4183-4c09-9c48-f63dd23b5514)
