### PR TITLE
Feature/a11y  form builder  add screen readable aria label to select options

### DIFF
--- a/components/form/builder/src/Select/Default/index.js
+++ b/components/form/builder/src/Select/Default/index.js
@@ -115,8 +115,15 @@ const DefaultSelect = ({
       {selectProps.children}
 
       <MoleculeSelectField {...selectProps} {...rendererResponse} multiselection={multiselection}>
-        {nextDataList.map(({value, text, description, leftAddon, ...others}) => (
-          <MoleculeSelectOption key={value} value={value} description={description} leftAddon={leftAddon} {...others}>
+        {nextDataList.map(({'aria-label': ariaLabel, value, text, description, leftAddon, ...others}) => (
+          <MoleculeSelectOption
+            aria-label={ariaLabel ?? text}
+            key={value}
+            value={value}
+            description={description}
+            leftAddon={leftAddon}
+            {...others}
+          >
             {text}
           </MoleculeSelectOption>
         ))}

--- a/components/form/builder/src/Switch/index.js
+++ b/components/form/builder/src/Switch/index.js
@@ -2,7 +2,7 @@ import {isValidElement, memo, useCallback} from 'react'
 
 import PropTypes from 'prop-types'
 
-import AtomSwitch, {atomSwitchColors, atomSwitchTypes} from '@s-ui/react-atom-switch'
+import AtomSwitch, {atomSwitchColors, atomSwitchDesigns} from '@s-ui/react-atom-switch'
 
 import {createComponentMemo, field} from '../prop-types/index.js'
 
@@ -29,7 +29,7 @@ const Switch = ({switchField, tabIndex, onChange, errors, alerts, renderer}) => 
 
   const switchProps = {
     color: atomSwitchColors.NEUTRAL,
-    design: atomSwitchTypes.SINGLE,
+    design: atomSwitchDesigns.SINGLE,
     initialValue: switched,
     label: switchField.label,
     name: switchField.id,


### PR DESCRIPTION
## Form Builder
### 🦾 A11Y

Add screen-readable aria-label to select options. Currently, it is equal to the value (ids mainly), and with this PR, it can be set manually or equal to the `Select` text by default.