### PR TITLE
fix(components/form/builder): use defaultChecked prop instead of initialValue

### DIFF
--- a/components/form/builder/src/Switch/index.js
+++ b/components/form/builder/src/Switch/index.js
@@ -30,7 +30,7 @@ const Switch = ({switchField, tabIndex, onChange, errors, alerts, renderer}) => 
   const switchProps = {
     color: atomSwitchColors.NEUTRAL,
     design: atomSwitchDesigns.SINGLE,
-    initialValue: switched,
+    defaultChecked: switched,
     label: switchField.label,
     name: switchField.id,
     onToggle: onChangeCallback,


### PR DESCRIPTION
Form builder atom switch -> use `defaultChecked` prop instead of `initialValue`